### PR TITLE
make 'Scheduled' and 'GPs' tabs only appear in NIDirect

### DIFF
--- a/origins_workflow/origins_workflow.links.task.yml
+++ b/origins_workflow/origins_workflow.links.task.yml
@@ -18,13 +18,3 @@ origins_workflow.needs_audit_tab:
   route_name: view.workflow_moderation.needs_audit
   parent_id: system.admin_content
   weight: 4
-origins_workflow.scheduled_tab:
-  title: 'Scheduled'
-  route_name: view.scheduler_scheduled_content.overview
-  parent_id: system.admin_content
-  weight: 5
-origins_workflow.gps:
-  title: 'GPs'
-  route_name: entity.gp.collection
-  parent_id: system.admin_content
-  weight: 6

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -92,7 +92,7 @@ function origins_workflow_form_alter(&$form, FormStateInterface $form_state, $fo
  * Implements hook_menu_links_discovered_alter().
  */
 function origins_workflow_menu_links_discovered_alter(&$links) {
-  // Add  'Site Themes', 'Scheduled' and 'GPs' options to the
+  // Add 'Site Themes', 'Scheduled' and 'GPs' options to the
   // dashboard menu if the nidirect_site_themes module is installed.
   if (!in_array('origins_workflow.site_themes', $links)) {
     if (\Drupal::service('module_handler')->moduleExists('nidirect_site_themes')) {

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -92,8 +92,8 @@ function origins_workflow_form_alter(&$form, FormStateInterface $form_state, $fo
  * Implements hook_menu_links_discovered_alter().
  */
 function origins_workflow_menu_links_discovered_alter(&$links) {
-  // Add a 'Site Themes' option in the dashboard menu
-  // if the nidirect_site_themes module is installed.
+  // Add  'Site Themes', 'Scheduled' and 'GPs' options to the
+  // dashboard menu if the nidirect_site_themes module is installed.
   if (!in_array('origins_workflow.site_themes', $links)) {
     if (\Drupal::service('module_handler')->moduleExists('nidirect_site_themes')) {
       $links['origins_workflow.site_themes'] = [
@@ -101,6 +101,18 @@ function origins_workflow_menu_links_discovered_alter(&$links) {
         'route_name' => 'nidirect_site_themes.site_theme_controller_disp',
         'parent' => 'system.admin_content',
         'weight' => -99,
+      ];
+      $links['origins_workflow.scheduled_tab'] = [
+        'title' => new TranslatableMarkup('Scheduled'),
+        'route_name' => 'view.scheduler_scheduled_content.overview',
+        'parent' => 'system.admin_content',
+        'weight' => 5,
+      ];
+      $links['origins_workflow.gps'] = [
+        'title' => new TranslatableMarkup('GPs'),
+        'route_name' => 'entity.gp.collection',
+        'parent' => 'system.admin_content',
+        'weight' => 6,
       ];
     }
   }


### PR DESCRIPTION
Make recent dashboard / content page changes apply to all sites, not just NIDirect