### PR TITLE
D8 nid 349 part3

### DIFF
--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -91,6 +91,10 @@ function origins_workflow_form_alter(&$form, FormStateInterface $form_state, $fo
   // Add an extra option to 'moderation state' on the admin/content form.
   if (($form_id == 'views_exposed_form') && ($form['#action'] == '/admin/content')) {
     $form['moderation_state']['#options']['Editorial']['editorial-unpublished'] = 'Unpublished';
+    // Hide the 'status' filter.
+    if (isset($form['status'])) {
+      $form['status']['#access'] = FALSE;
+    }
     // Add custom validation function.
     array_unshift($form['#validate'], '_origins_workflow_admin_content_validate');
   }

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains code that provides user dashboard.
+ * Contains code that amends the admin/content view.
  */
 
 use Drupal\Core\Entity\EntityInterface;
@@ -100,12 +100,16 @@ function origins_workflow_form_alter(&$form, FormStateInterface $form_state, $fo
   }
 }
 
+/**
+ * Custom validation for admin/content form.
+ */
 function _origins_workflow_admin_content_validate(&$form, FormStateInterface $form_state) {
   // Set the hidden 'Status' filter if moderation state was set to
   // 'published' or 'unpublished'.
   if ($form_state->getValue('moderation_state') == 'editorial-unpublished') {
     $form_state->setValue('status', '0');
-  } elseif ($form_state->getValue('moderation_state') == 'editorial-published') {
+  }
+  elseif ($form_state->getValue('moderation_state') == 'editorial-published') {
     $form_state->setValue('status', '1');
   }
 }

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -107,9 +107,11 @@ function _origins_workflow_admin_content_validate(&$form, FormStateInterface $fo
   // Set the hidden 'Status' filter if moderation state was set to
   // 'published' or 'unpublished'.
   if ($form_state->getValue('moderation_state') == 'editorial-unpublished') {
+    // Set 'status' filter to 'Unpublished'.
     $form_state->setValue('status', '0');
   }
   elseif ($form_state->getValue('moderation_state') == 'editorial-published') {
+    // Set 'status' filter to 'Published'.
     $form_state->setValue('status', '1');
   }
 }

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -90,7 +90,7 @@ function origins_workflow_form_alter(&$form, FormStateInterface $form_state, $fo
 
   // Add an extra option to 'moderation state' on the admin/content form.
   if (($form_id == 'views_exposed_form') && ($form['#action'] == '/admin/content')) {
-    $form['moderation_state']['#options']['Editorial']['editorial-unpublished'] = 'Unpublished';
+    $form['moderation_state']['#options']['Editorial']['editorial-unpublished'] = t('Unpublished');
     // Hide the 'status' filter.
     if (isset($form['status'])) {
       $form['status']['#access'] = FALSE;

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\views\Plugin\views\query\QueryPluginBase;
 use Drupal\views\ViewExecutable;
 use Drupal\user\Entity\User;
 
@@ -85,6 +86,11 @@ function origins_workflow_form_alter(&$form, FormStateInterface $form_state, $fo
       // Hide the audit date for anyone else.
       $form['field_next_audit_due']['#access'] = FALSE;
     }
+  }
+
+  // Add an extra option to 'moderation state' on the admin/content form.
+  if (($form_id == 'views_exposed_form') && ($form['#action'] == '/admin/content')) {
+    $form['moderation_state']['#options']['Editorial']['editorial-unpublished'] = 'Unpublished';
   }
 }
 
@@ -176,5 +182,24 @@ function origins_workflow_hide_moderation_field(&$view) {
 function origins_workflow_menu_local_tasks_alter(&$data, $route_name) {
   if (isset($data['tabs'][1]) && isset($data['tabs'][1]['content_moderation.moderated_content'])) {
     unset($data['tabs'][1]['content_moderation.moderated_content']);
+  }
+}
+
+/**
+ * Implements hook_views_query_alter().
+ */
+function origins_workflow_views_query_alter(ViewExecutable $view, QueryPluginBase $query) {
+  if ($view->id() == 'content') {
+    // In the case where 'Moderation State' has been set to 'Published',
+    // change the query to make it act as if 'Any' had been selected.,
+    // (as the hidden 'Status' filter will do the work)
+    if (isset($view->exposed_raw_input['status']) && ($view->exposed_raw_input['status'] == 1)) {
+      if (isset($view->exposed_raw_input['moderation_state']) && ($view->exposed_raw_input['moderation_state'] == 'editorial-published')) {
+        unset($query->relationships['content_moderation_state']);
+        unset($query->relationships['node']);
+        unset($query->where[1]['conditions'][2]);
+        unset($query->where[1]['conditions'][3]);
+      }
+    }
   }
 }

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -91,6 +91,18 @@ function origins_workflow_form_alter(&$form, FormStateInterface $form_state, $fo
   // Add an extra option to 'moderation state' on the admin/content form.
   if (($form_id == 'views_exposed_form') && ($form['#action'] == '/admin/content')) {
     $form['moderation_state']['#options']['Editorial']['editorial-unpublished'] = 'Unpublished';
+    // Add custom validation function.
+    array_unshift($form['#validate'], '_origins_workflow_admin_content_validate');
+  }
+}
+
+function _origins_workflow_admin_content_validate(&$form, FormStateInterface $form_state) {
+  // Set the hidden 'Status' filter if moderation state was set to
+  // 'published' or 'unpublished'.
+  if ($form_state->getValue('moderation_state') == 'editorial-unpublished') {
+    $form_state->setValue('status', '0');
+  } elseif ($form_state->getValue('moderation_state') == 'editorial-published') {
+    $form_state->setValue('status', '1');
   }
 }
 

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -190,15 +190,21 @@ function origins_workflow_menu_local_tasks_alter(&$data, $route_name) {
  */
 function origins_workflow_views_query_alter(ViewExecutable $view, QueryPluginBase $query) {
   if ($view->id() == 'content') {
-    // In the case where 'Moderation State' has been set to 'Published',
-    // change the query to make it act as if 'Any' had been selected.,
-    // (as the hidden 'Status' filter will do the work)
-    if (isset($view->exposed_raw_input['status']) && ($view->exposed_raw_input['status'] == 1)) {
-      if (isset($view->exposed_raw_input['moderation_state']) && ($view->exposed_raw_input['moderation_state'] == 'editorial-published')) {
-        unset($query->relationships['content_moderation_state']);
-        unset($query->relationships['node']);
-        unset($query->where[1]['conditions'][2]);
-        unset($query->where[1]['conditions'][3]);
+    // In the case where 'Moderation State' has been set to
+    // 'Published' or 'Unpublished' change the query to make
+    // it act as if 'Any' had been selected (as the hidden
+    // 'Status' filter will do the work).
+    if (isset($view->exposed_raw_input['status'])) {
+      if ($view->exposed_raw_input['status'] != 'All') {
+        if (isset($view->exposed_raw_input['moderation_state'])) {
+          if (in_array($view->exposed_raw_input['moderation_state'],
+            ['editorial-published', 'editorial-unpublished'])) {
+            unset($query->relationships['content_moderation_state']);
+            unset($query->relationships['node']);
+            unset($query->where[1]['conditions'][2]);
+            unset($query->where[1]['conditions'][3]);
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Changes relate to the admin 'Content' view.
The goal is to display 'moderation state' and allow appropriate filtering on this state for content which is moderated.
In addition to this, display published/unpublished status and allow filtering for content which is not moderated.
Note that the 'Status' column is used in both cases, and the 'Status' filter is also used in both cases.
This has been achieved by adding both 'Status' and 'Moderation State' filters to the content page, but the 'Status' filter is hidden. The value of this hidden filter is set in code depending on the value of the 'moderation state' filter.
See related PR https://github.com/dof-dss/nidirect-drupal/pull/91  for the view changes, this PR only contains the code changes.