### PR TITLE
D8NID-262 improved taxonomy handling

### DIFF
--- a/origins_taxonomy_access/origins_taxonomy_access.info.yml
+++ b/origins_taxonomy_access/origins_taxonomy_access.info.yml
@@ -1,0 +1,10 @@
+name: 'Taxonomy access control'
+type: module
+description: 'Provides permissions driven, configurable taxonomy access to site roles.'
+core: 8.x
+version: '8.x-1.0'
+package: 'Origins'
+dependencies:
+  - drupal:taxonomy
+  - taxonomy_manager
+  - taxonomy_access_fix

--- a/origins_taxonomy_access/origins_taxonomy_access.module
+++ b/origins_taxonomy_access/origins_taxonomy_access.module
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @file
+ * Hook functions for origins_taxonomy_access module.
+ */
+
+/**
+ * Implements hook_preprocess_item_list().
+ *
+ * We use this to manipulate the taxonomy manager options. it doesn't
+ * use form API to generate this list so by preprocessing the theme item
+ * it uses, we can very, very selectively prune off the vocabs the user
+ * isn't allowed to access.
+ *
+ * Anything more substantial, we probably need to re-route the request
+ * to our own controller class and build up the page render array ourselves.
+ */
+function origins_taxonomy_access_preprocess_item_list(&$variables) {
+  if (\Drupal::routeMatch()->getRouteName() != 'taxonomy_manager.admin') {
+    return;
+  }
+
+  foreach ($variables['items'] as $index => $item) {
+    // Extract the term id from the URL (that's all we have to work with at this level).
+    $matches = [];
+    preg_match('#\/admin\/structure\/taxonomy_manager\/voc/(.+)\"#', $item['value']->getGeneratedLink(), $matches);
+    $vocab_id = $matches[1];
+
+    if (\Drupal::currentUser()->hasPermission('edit terms in ' . $vocab_id) == FALSE) {
+      unset($variables['items'][$index]);
+    }
+  }
+}

--- a/origins_taxonomy_access/origins_taxonomy_access.services.yml
+++ b/origins_taxonomy_access/origins_taxonomy_access.services.yml
@@ -1,0 +1,5 @@
+services:
+  origins_taxonomy_access.route_subscriber:
+    class: Drupal\origins_taxonomy_access\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/origins_taxonomy_access/src/Routing/RouteSubscriber.php
+++ b/origins_taxonomy_access/src/Routing/RouteSubscriber.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Drupal\origins_taxonomy_access\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Drupal\Core\Routing\RoutingEvents;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Listens to the dynamic route events.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * Override from base class to set lighter
+   * event priority; execute after taxonomy_access_fix
+   * RouteSubscriber callbacks.
+   *
+   * See https://www.drupal.org/docs/8/creating-custom-modules/subscribe-to-and-dispatch-events#s-event-subscriber-priorities.
+   *
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[RoutingEvents::ALTER] = ['onAlterRoutes', -100];
+    return $events;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    /* ==== Adjust route parameters for: Taxonomy manager module. ===================
+     * Taxonomy manager isn't very precise with mapping its own routes to permissions
+     * so here we use taxonomy_access_fix's granular defined permissions to map onto
+     * the routes from taxonomy_manager.
+     *
+     * It's not a perfect fit, so AJAX routes like search/autocomplete map to a more
+     * general 'edit' permission for relative safety.
+     */
+    $vocab_routes_to_alter = [
+      'taxonomy_manager.admin_vocabulary',
+      'taxonomy_manager.admin_vocabulary.add',
+      'taxonomy_manager.admin_vocabulary.move',
+      'taxonomy_manager.admin_vocabulary.search',
+      'taxonomy_manager.admin_vocabulary.delete',
+      'taxonomy_manager.admin_vocabulary.searchautocomplete',
+    ];
+
+    foreach ($vocab_routes_to_alter as $route_id) {
+      $route = $collection->get($route_id);
+      $route->setRequirements([
+        '_custom_access' => '\Drupal\origins_taxonomy_access\TaxonomyVocabAccess::handleAccess',
+      ]);
+      $route_elements = explode('.', $route_id);
+      $op = end($route_elements);
+
+      // Set an operation option for us to latch onto in the handler class, unless it's the vocab overview route.
+      if ($op != 'admin_vocabulary') {
+        $route->setOption('op', $op);
+      }
+    }
+
+    // Amend overview and subtree route access to be more relaxed; map to the core taxonomy overview permission.
+    $general_routes = [
+      'taxonomy_manager.admin',
+      'taxonomy_manager.subTree',
+    ];
+
+    foreach ($general_routes as $route_id) {
+      $route = $collection->get($route_id);
+      $route->setRequirement('_permission', 'access taxonomy overview');
+    }
+
+    // === Adjust route parameters for: Taxonomy core module (after taxonomy_access_fix has applied changes). ===
+    if ($route = $collection->get('entity.taxonomy_vocabulary.collection')) {
+      // Replace custom access callback with standard high level permission so core's taxonomy module's
+      // menu items don't leave a stub im the 'Structure' menu making for a confusing non-admin editor experience.
+      $route->setRequirements([
+        '_permission' => 'administer taxonomy',
+      ]);
+      // Clear any existing route options.
+      $route->setOptions([]);
+    }
+  }
+
+}

--- a/origins_taxonomy_access/src/TaxonomyVocabAccess.php
+++ b/origins_taxonomy_access/src/TaxonomyVocabAccess.php
@@ -7,6 +7,11 @@ use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\taxonomy\VocabularyInterface;
 use Symfony\Component\Routing\Route;
 
+/**
+ * Validates permissions for users against taxonomy vocabularies and operations on them.
+ *
+ * @package Drupal\origins_taxonomy_access
+ */
 class TaxonomyVocabAccess {
 
   /**

--- a/origins_taxonomy_access/src/TaxonomyVocabAccess.php
+++ b/origins_taxonomy_access/src/TaxonomyVocabAccess.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\origins_taxonomy_access;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\taxonomy\VocabularyInterface;
+use Symfony\Component\Routing\Route;
+
+class TaxonomyVocabAccess {
+
+  /**
+   * Access callback for common CUSTOM taxonomy operations.
+   */
+  public static function handleAccess(Route $route, RouteMatchInterface $match) {
+    $op = $route->getOption('op');
+    $taxonomy_vocabulary = $match->getParameter('taxonomy_vocabulary');
+
+    // Admin: always.
+    if (\Drupal::currentUser()->hasPermission('administer taxonomy')) {
+      return AccessResult::allowed();
+    }
+    else {
+      // Check user can view terms in this vocab.
+      if ($match->getRouteName() == 'taxonomy_manager.admin_vocabulary') {
+        return AccessResult::allowedIfHasPermission(\Drupal::currentUser(), 'view terms in ' . $taxonomy_vocabulary->id());
+      }
+
+      // Loosely map these outlying tasks to a general permission for the vocab.
+      if (in_array($op, ['search', 'searchautocomplete'])) {
+        return AccessResult::allowedIfHasPermission(\Drupal::currentUser(), 'edit terms in ' . $taxonomy_vocabulary->id());
+      }
+
+      // Move == reorder; difference in semantics between taxonomy_manager and taxonomy_access_fix.
+      if ($op == 'move') {
+        $op = 'reorder';
+      }
+
+      // Check permissions for add, delete, reorder defined by taxonomy_access_fix; defined per vocab.
+      if (\Drupal::currentUser()->hasPermission($op . ' terms in ' . $taxonomy_vocabulary->id())) {
+        return AccessResult::allowed();
+      }
+    }
+
+    // Final fallback: return access denied.
+    return AccessResult::forbidden();
+  }
+
+}

--- a/origins_workflow/origins_workflow.install
+++ b/origins_workflow/origins_workflow.install
@@ -26,7 +26,7 @@ function origins_workflow_install() {
     '_editor' => 'editor_user',
     '_admin' => 'admin_user'
   ];
-  if (\Drupal::service('module_handler')->moduleExists('nidirect_site_themes')) {
+  if (\Drupal::service('module_handler')->moduleExists('nidirect_common')) {
     // Additional roles/users for NIDirect.
     $name_list += ['_news_super' => 'news_supervisor',
       '_gp_author' => 'gp_author_user',

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -121,15 +121,9 @@ function _origins_workflow_admin_content_validate(&$form, FormStateInterface $fo
  */
 function origins_workflow_menu_links_discovered_alter(&$links) {
   // Add 'Site Themes', 'Scheduled' and 'GPs' options to the
-  // dashboard menu if the nidirect_site_themes module is installed.
+  // dashboard menu if the nidirect_common module is installed.
   if (!in_array('origins_workflow.site_themes', $links)) {
-    if (\Drupal::service('module_handler')->moduleExists('nidirect_site_themes')) {
-      $links['origins_workflow.site_themes'] = [
-        'title' => new TranslatableMarkup('Site Themes'),
-        'route_name' => 'nidirect_site_themes.site_theme_controller_disp',
-        'parent' => 'system.admin_content',
-        'weight' => -99,
-      ];
+    if (\Drupal::service('module_handler')->moduleExists('nidirect_common')) {
       $links['origins_workflow.scheduled_tab'] = [
         'title' => new TranslatableMarkup('Scheduled'),
         'route_name' => 'view.scheduler_scheduled_content.overview',


### PR DESCRIPTION
- Strip away the existing route for the 'Site Themes' dashboard report;
this supersedes it.
- Remove references to old module from workflow install module. Replaced
with 'nidirect_common' as a placeholder that will serve the same
purpose.

Corresponds to https://github.com/dof-dss/nidirect-drupal/pull/93 for NIDirect