### PR TITLE
Remove nidirect tags and re-tag for origins project

### DIFF
--- a/origins_workflow/tests/src/Nightwatch/Tests/AdminTest.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/AdminTest.js
@@ -1,14 +1,9 @@
 module.exports = {
-  '@tags': ['nidirect-migrations', 'nidirect-files'],
+  '@tags': ['origins', 'origins_workflow'],
 
   'Test login': browser => {
     browser
       .drupalLogin({ name: process.env.NW_TEST_USER_PREFIX + '_admin', password: process.env.TEST_PASS });
-
-    browser
-      .drupalRelativeURL('/admin/site_themes')
-      .expect.element('h1.page-title')
-      .text.to.contain('Site Themes');
 
     browser
       .drupalRelativeURL('/node/add')

--- a/origins_workflow/tests/src/Nightwatch/Tests/AppsTest.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/AppsTest.js
@@ -1,14 +1,9 @@
 module.exports = {
-  '@tags': ['nidirect-migrations', 'nidirect-files'],
+  '@tags': ['origins', 'origins_workflow'],
 
   'Test login': browser => {
     browser
       .drupalLogin({ name: process.env.NW_TEST_USER_PREFIX + '_apps', password: process.env.TEST_PASS });
-
-    browser
-      .drupalRelativeURL('/admin/site_themes')
-      .expect.element('h1.page-title')
-      .text.to.contain('Site Themes');
 
     browser
       .drupalRelativeURL('/node/add')

--- a/origins_workflow/tests/src/Nightwatch/Tests/AuthenticatedTest.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/AuthenticatedTest.js
@@ -1,14 +1,9 @@
 module.exports = {
-  '@tags': ['nidirect-migrations', 'nidirect-files'],
+  '@tags': ['origins', 'origins_workflow'],
 
   'Test login': browser => {
     browser
       .drupalLogin({ name: process.env.NW_TEST_USER_PREFIX + '_authenticated', password: process.env.TEST_PASS });
-
-    browser
-      .drupalRelativeURL('/admin/site_themes')
-      .expect.element('h1.page-title')
-      .text.to.contain('Site Themes');
 
     browser
       .drupalRelativeURL('/node/add')

--- a/origins_workflow/tests/src/Nightwatch/Tests/AuthorTest.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/AuthorTest.js
@@ -1,14 +1,9 @@
 module.exports = {
-  '@tags': ['nidirect-migrations', 'nidirect-files'],
+  '@tags': ['origins', 'origins_workflow'],
 
   'Test login': browser => {
     browser
       .drupalLogin({ name: process.env.NW_TEST_USER_PREFIX + '_author', password: process.env.TEST_PASS });
-
-    browser
-      .drupalRelativeURL('/admin/site_themes')
-      .expect.element('h1.page-title')
-      .text.to.contain('Site Themes');
 
     browser
       .drupalRelativeURL('/node/add')

--- a/origins_workflow/tests/src/Nightwatch/Tests/DrivingSupervisorTest.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/DrivingSupervisorTest.js
@@ -1,14 +1,9 @@
 module.exports = {
-  '@tags': ['nidirect-migrations', 'nidirect-files'],
+  '@tags': ['origins', 'origins_workflow'],
 
   'Test login': browser => {
     browser
       .drupalLogin({ name: process.env.NW_TEST_USER_PREFIX + '_driving_super', password: process.env.TEST_PASS });
-
-    browser
-      .drupalRelativeURL('/admin/site_themes')
-      .expect.element('h1.page-title')
-      .text.to.contain('Site Themes');
 
     browser
       .drupalRelativeURL('/node/add')

--- a/origins_workflow/tests/src/Nightwatch/Tests/EditorTest.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/EditorTest.js
@@ -1,14 +1,9 @@
 module.exports = {
-  '@tags': ['nidirect-migrations', 'nidirect-files'],
+  '@tags': ['origins', 'origins_workflow'],
 
   'Test login': browser => {
     browser
       .drupalLogin({ name: process.env.NW_TEST_USER_PREFIX + '_editor', password: process.env.TEST_PASS });
-
-    browser
-      .drupalRelativeURL('/admin/site_themes')
-      .expect.element('h1.page-title')
-      .text.to.contain('Site Themes');
 
     browser
       .drupalRelativeURL('/node/add')

--- a/origins_workflow/tests/src/Nightwatch/Tests/GPAuthorTest.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/GPAuthorTest.js
@@ -1,14 +1,9 @@
 module.exports = {
-  '@tags': ['nidirect-migrations', 'nidirect-files'],
+  '@tags': ['origins', 'origins_workflow'],
 
   'Test login': browser => {
     browser
       .drupalLogin({ name: process.env.NW_TEST_USER_PREFIX + '_gp_author', password: process.env.TEST_PASS });
-
-    browser
-      .drupalRelativeURL('/admin/site_themes')
-      .expect.element('h1.page-title')
-      .text.to.contain('Site Themes');
 
     browser
       .drupalRelativeURL('/node/add')

--- a/origins_workflow/tests/src/Nightwatch/Tests/HCAuthorTest.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/HCAuthorTest.js
@@ -1,14 +1,9 @@
 module.exports = {
-  '@tags': ['nidirect-migrations', 'nidirect-files'],
+  '@tags': ['origins', 'origins_workflow'],
 
   'Test login': browser => {
     browser
       .drupalLogin({ name: process.env.NW_TEST_USER_PREFIX + '_hc_author', password: process.env.TEST_PASS });
-
-    browser
-      .drupalRelativeURL('/admin/site_themes')
-      .expect.element('h1.page-title')
-      .text.to.contain('Site Themes');
 
     browser
       .drupalRelativeURL('/node/add')

--- a/origins_workflow/tests/src/Nightwatch/Tests/HCSupervisorTest.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/HCSupervisorTest.js
@@ -1,14 +1,9 @@
 module.exports = {
-  '@tags': ['nidirect-migrations', 'nidirect-files'],
+  '@tags': ['origins', 'origins_workflow'],
 
   'Test login': browser => {
     browser
       .drupalLogin({ name: process.env.NW_TEST_USER_PREFIX + '_hc_super', password: process.env.TEST_PASS });
-
-    browser
-      .drupalRelativeURL('/admin/site_themes')
-      .expect.element('h1.page-title')
-      .text.to.contain('Site Themes');
 
     browser
       .drupalRelativeURL('/node/add')

--- a/origins_workflow/tests/src/Nightwatch/Tests/NewsSupervisorTest.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/NewsSupervisorTest.js
@@ -1,14 +1,9 @@
 module.exports = {
-  '@tags': ['nidirect-migrations', 'nidirect-files'],
+  '@tags': ['origins', 'origins_workflow'],
 
   'Test login': browser => {
     browser
       .drupalLogin({ name: process.env.NW_TEST_USER_PREFIX + '_news_super', password: process.env.TEST_PASS });
-
-    browser
-      .drupalRelativeURL('/admin/site_themes')
-      .expect.element('h1.page-title')
-      .text.to.contain('Site Themes');
 
     browser
       .drupalRelativeURL('/node/add')

--- a/origins_workflow/tests/src/Nightwatch/Tests/SupervisorTest.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/SupervisorTest.js
@@ -1,14 +1,9 @@
 module.exports = {
-  '@tags': ['nidirect-migrations', 'nidirect-files'],
+  '@tags': ['origins', 'origins_workflow'],
 
   'Test login': browser => {
     browser
       .drupalLogin({ name: process.env.NW_TEST_USER_PREFIX + '_super', password: process.env.TEST_PASS });
-
-    browser
-      .drupalRelativeURL('/admin/site_themes')
-      .expect.element('h1.page-title')
-      .text.to.contain('Site Themes');
 
     browser
       .drupalRelativeURL('/node/add')


### PR DESCRIPTION
Ensures we can run origins and nidirect test groups separately if required.