### PR TITLE
Safely handle access to taxo pages for anonymous users

### DIFF
--- a/origins_taxonomy_access/src/Routing/RouteSubscriber.php
+++ b/origins_taxonomy_access/src/Routing/RouteSubscriber.php
@@ -51,6 +51,8 @@ class RouteSubscriber extends RouteSubscriberBase {
       $route->setRequirements([
         '_custom_access' => '\Drupal\origins_taxonomy_access\TaxonomyVocabAccess::handleAccess',
       ]);
+      $route->setOption('_admin_route', TRUE);
+
       $route_elements = explode('.', $route_id);
       $op = end($route_elements);
 

--- a/origins_taxonomy_access/src/TaxonomyVocabAccess.php
+++ b/origins_taxonomy_access/src/TaxonomyVocabAccess.php
@@ -30,25 +30,26 @@ class TaxonomyVocabAccess {
   public static function handleAccess(Route $route, RouteMatchInterface $match) {
     $op = $route->getOption('op');
     $taxonomy_vocabulary = $match->getParameter('taxonomy_vocabulary');
+    $current_user = \Drupal::currentUser();
 
     // Admin: always.
-    if (\Drupal::currentUser()->hasPermission('administer taxonomy')) {
+    if ($current_user->hasPermission('administer taxonomy')) {
       return AccessResult::allowed();
     }
     else {
       // If the user can't view admin pages, reject the request early.
-      if (\Drupal::currentUser()->hasPermission('access administration pages') == FALSE) {
+      if ($current_user->hasPermission('access administration pages') == FALSE) {
         return AccessResult::forbidden();
       }
 
       // Check user can view terms in this vocab.
       if ($match->getRouteName() == 'taxonomy_manager.admin_vocabulary') {
-        return AccessResult::allowedIfHasPermission('view terms in ' . $taxonomy_vocabulary->id());
+        return AccessResult::allowedIfHasPermission($current_user, 'view terms in ' . $taxonomy_vocabulary->id());
       }
 
       // Loosely map these outlying tasks to a general permission for the vocab.
       if (in_array($op, ['search', 'searchautocomplete'])) {
-        return AccessResult::allowedIfHasPermission('edit terms in ' . $taxonomy_vocabulary->id());
+        return AccessResult::allowedIfHasPermission($current_user, 'edit terms in ' . $taxonomy_vocabulary->id());
       }
 
       // Move == reorder; difference in semantics between taxonomy_manager and taxonomy_access_fix.
@@ -57,7 +58,7 @@ class TaxonomyVocabAccess {
       }
 
       // Check permissions for add, delete, reorder defined by taxonomy_access_fix; defined per vocab.
-      if (\Drupal::currentUser()->hasPermission($op . ' terms in ' . $taxonomy_vocabulary->id())) {
+      if ($current_user->hasPermission($op . ' terms in ' . $taxonomy_vocabulary->id())) {
         return AccessResult::allowed();
       }
     }

--- a/origins_taxonomy_access/src/TaxonomyVocabAccess.php
+++ b/origins_taxonomy_access/src/TaxonomyVocabAccess.php
@@ -16,6 +16,16 @@ class TaxonomyVocabAccess {
 
   /**
    * Access callback for common CUSTOM taxonomy operations.
+   *
+   * We generally DO want to allow anonymous users access to view term pages.
+   * We can't re-use that permission for taxonomy manager routes, because it would allow
+   * anonymous users the ability to view those routes/inspect the term hierarchy and potentially manipulate
+   * taxonomy data which would be a Bad Thing (TM).
+   *
+   * So we're predicating this approach by saying something like:
+   * - If you can administer all things taxonomy (aka: Lord Of The Terms), then grant access early.
+   * - If you can't view the admin pages (aka: Anonymous User), then reject early.
+   * - Otherwise, evaluate what you can/cannot do in more detail.
    */
   public static function handleAccess(Route $route, RouteMatchInterface $match) {
     $op = $route->getOption('op');
@@ -26,14 +36,19 @@ class TaxonomyVocabAccess {
       return AccessResult::allowed();
     }
     else {
+      // If the user can't view admin pages, reject the request early.
+      if (\Drupal::currentUser()->hasPermission('access administration pages') == FALSE) {
+        return AccessResult::forbidden();
+      }
+
       // Check user can view terms in this vocab.
       if ($match->getRouteName() == 'taxonomy_manager.admin_vocabulary') {
-        return AccessResult::allowedIfHasPermission(\Drupal::currentUser(), 'view terms in ' . $taxonomy_vocabulary->id());
+        return AccessResult::allowedIfHasPermission('view terms in ' . $taxonomy_vocabulary->id());
       }
 
       // Loosely map these outlying tasks to a general permission for the vocab.
       if (in_array($op, ['search', 'searchautocomplete'])) {
-        return AccessResult::allowedIfHasPermission(\Drupal::currentUser(), 'edit terms in ' . $taxonomy_vocabulary->id());
+        return AccessResult::allowedIfHasPermission('edit terms in ' . $taxonomy_vocabulary->id());
       }
 
       // Move == reorder; difference in semantics between taxonomy_manager and taxonomy_access_fix.


### PR DESCRIPTION
Ensures anonymous users can see canonical taxonomy term pages, but denies them access to the adapted taxonomy manager routes.