### PR TITLE
Avoid dabbling with form components if config exists

### DIFF
--- a/origins_toc/origins_toc.module
+++ b/origins_toc/origins_toc.module
@@ -165,14 +165,16 @@ function origins_toc_entity_presave(EntityInterface $entity) {
         $field->save();
       }
 
-      // Enable the fields in the form display.
+      // Enable the fields in the form display, if haven't already got them.
       $form_display = \Drupal::entityTypeManager()->getStorage('entity_form_display')->load('node.' . $entity->id() . '.default');
-      $form_display->setComponent('field_toc_enable', [
-        'type' => 'boolean_checkbox',
-        'label' => 'above',
-        'settings' => ['link_to_entity' => 'false'],
-      ])->save();
-
+      if (empty($form_display->getComponent('field_toc_enable'))) {
+        var_dump(date('Y-m-d H:i:s', time()) . 'Enable the fields in the form display.');
+        $form_display->setComponent('field_toc_enable', [
+          'type' => 'boolean_checkbox',
+          'label' => 'above',
+          'settings' => ['link_to_entity' => 'false'],
+        ])->save();
+      }
     }
     else {
       // Delete the 'toc enable' field from this entity if it exists.

--- a/origins_toc/origins_toc.module
+++ b/origins_toc/origins_toc.module
@@ -168,7 +168,6 @@ function origins_toc_entity_presave(EntityInterface $entity) {
       // Enable the fields in the form display, if haven't already got them.
       $form_display = \Drupal::entityTypeManager()->getStorage('entity_form_display')->load('node.' . $entity->id() . '.default');
       if (empty($form_display->getComponent('field_toc_enable'))) {
-        var_dump(date('Y-m-d H:i:s', time()) . 'Enable the fields in the form display.');
         $form_display->setComponent('field_toc_enable', [
           'type' => 'boolean_checkbox',
           'label' => 'above',


### PR DESCRIPTION
Re-setting form display component settings when installing from existing site config files triggers an obscure, silent (but deadly) issue whereby the content type won't show in Drupal's listings nor can be re-added manually or programmatically. Almost as if it's half-baked and permanently stuck.

This extra check in the presave hook ensures that fresh installs are able to add the toc_enable field storage and config instances, but also allow us to reinstall from existing config without ending up in the Sarlacc pit of config import doom mentioned above.