### PR TITLE
Check for presence of fields before trying to set them on form display

### DIFF
--- a/origins_common/inc/layout_builder_search.inc
+++ b/origins_common/inc/layout_builder_search.inc
@@ -149,17 +149,21 @@ function layout_builder_search_node_type_presave(NodeType $entity) {
 
     // Enable the fields in the form display.
     $form_display = \Drupal::entityTypeManager()->getStorage('entity_form_display')->load('node.' . $entity->id() . '.default');
-    $form_display->setComponent('field_lb_search_enable', [
-      'type' => 'boolean_checkbox',
-      'label' => 'above',
-      'settings' => ['link_to_entity' => 'false'],
-    ]);
+    if (empty($form_display->getComponent('field_lb_search_enable'))) {
+      $form_display->setComponent('field_lb_search_enable', [
+        'type' => 'boolean_checkbox',
+        'label' => 'above',
+        'settings' => ['link_to_entity' => 'false'],
+      ]);
+    }
 
-    $form_display->setComponent('field_lb_search_content', [
-      'type' => 'string_textarea',
-      'label' => 'above',
-      'settings' => ['link_to_entity' => 'false'],
-    ])->save();
+    if (empty($form_display->getComponent('field_lb_search_content'))) {
+      $form_display->setComponent('field_lb_search_content', [
+        'type' => 'string_textarea',
+        'label' => 'above',
+        'settings' => ['link_to_entity' => 'false'],
+      ])->save();
+    }
 
   }
   else {

--- a/origins_toc/origins_toc.module
+++ b/origins_toc/origins_toc.module
@@ -76,7 +76,7 @@ function origins_toc_form_node_type_form_alter(&$form, FormStateInterface $form_
   $form['toc']['toc_config']['notice'] = [
     '#type' => 'html_tag',
     '#tag' => 'p',
-    '#value' => 'The setting below currently have no effect on the ToC creation.',
+    '#value' => 'The settings below currently have no effect on the ToC creation.',
     '#attributes' => ['style' => 'color: red'],
   ];
 


### PR DESCRIPTION
This mirrors a 'fix' put in on origins_toc module in the past. With this in place + some tweaked config in NIDirect, things install cleanly again for all content types.