### PR TITLE
D8 un 69

### DIFF
--- a/origins_workflow/README.md
+++ b/origins_workflow/README.md
@@ -1,7 +1,29 @@
 # Origins Workflow Module
 
-Note that some functional and Nightwatch tests have been included with this module.
+# Workflow
 
+If installing this module in a new site, head to teh /admin/config/workflow/workflows admin page. Here you should delete
+the default 'Editorial' workflow as we will be using the 'NICS Editorial Workflow' that is installed with this module.
+
+Edit the workflow by clicking 'Edit'. The 'states' and 'transitions' should be OK for your site, but you should make sure
+that you edit the 'Content types' in the 'This Workflow Applies To' section and select the content types that you wish
+workflow to apply to.
+
+# Auditing
+
+Auditing is the process of automatically flagging content to be audited 6 months after publication.
+The first step is to select teh content types that you wish auditing to apply to at /admin/config/origins_workflow/auditsettings.
+Once this has been done, you will see that the 'field_next_audit_due' field has been added to the selected content types.
+When you publish a new node of an 'auditable' content type, the 'origins_workflow_entity_presave' function will automatically set
+an audit date six months in the future.
+Later, you can search for nodes on your site that are due for audit at /admin/workflow/needs-audit.
+When you view a node that is due for audit, you will see an 'Audit this published content' link. If you (or someone with
+appropriate permissions) clicks on this link, then there will be a further 'Audit this published content' link - if you click
+this as well then the auditing process is completed and the audit date is set a further six months in the future.
+
+# Testing
+
+Note that some functional and Nightwatch tests have been included with this module.
 For the Nightwatch tests to work, however, two environment variables must be set:
 
 NW_TEST_USER_PREFIX  (a prefix for the test user names, so that user names are not viewable in source code)

--- a/origins_workflow/README.md
+++ b/origins_workflow/README.md
@@ -2,7 +2,7 @@
 
 # Workflow
 
-If installing this module in a new site, head to teh /admin/config/workflow/workflows admin page. Here you should delete
+If installing this module in a new site, head to the /admin/config/workflow/workflows admin page. Here you should delete
 the default 'Editorial' workflow as we will be using the 'NICS Editorial Workflow' that is installed with this module.
 
 Edit the workflow by clicking 'Edit'. The 'states' and 'transitions' should be OK for your site, but you should make sure
@@ -12,7 +12,7 @@ workflow to apply to.
 # Auditing
 
 Auditing is the process of automatically flagging content to be audited 6 months after publication.
-The first step is to select teh content types that you wish auditing to apply to at /admin/config/origins_workflow/auditsettings.
+The first step is to select the content types that you wish auditing to apply to at /admin/config/origins_workflow/auditsettings.
 Once this has been done, you will see that the 'field_next_audit_due' field has been added to the selected content types.
 When you publish a new node of an 'auditable' content type, the 'origins_workflow_entity_presave' function will automatically set
 an audit date six months in the future.

--- a/origins_workflow/README.md
+++ b/origins_workflow/README.md
@@ -21,6 +21,11 @@ When you view a node that is due for audit, you will see an 'Audit this publishe
 appropriate permissions) clicks on this link, then there will be a further 'Audit this published content' link - if you click
 this as well then the auditing process is completed and the audit date is set a further six months in the future.
 
+N.B. If developers wish to test auditing by setting audit dates manually, this can be done in one of two ways:
+- by temporarily commenting out this line in origins_workflow_form_alter
+$form['field_next_audit_due']['#access'] = FALSE;
+- by manually setting audit dates in the database in the node__field_next_audit_due table
+
 # Testing
 
 Note that some functional and Nightwatch tests have been included with this module.

--- a/origins_workflow/config/optional/views.view.workflow_moderation.yml
+++ b/origins_workflow/config/optional/views.view.workflow_moderation.yml
@@ -23,7 +23,6 @@ description: 'NIDirect custom views to appear under the custom ''My Dashboard'' 
 tag: ''
 base_table: node_field_revision
 base_field: vid
-core: 8.x
 display:
   default:
     display_plugin: default
@@ -737,6 +736,8 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -774,6 +775,8 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -825,6 +828,8 @@ display:
               health_condition_supervisor_user: '0'
               driving_instructor_supervisor_user: '0'
             placeholder: ''
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -877,6 +882,8 @@ display:
               health_condition_supervisor_user: '0'
               driving_instructor_supervisor_user: '0'
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -978,6 +985,8 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1015,6 +1024,8 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1066,6 +1077,8 @@ display:
               health_condition_supervisor_user: '0'
               driving_instructor_supervisor_user: '0'
             placeholder: ''
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1111,6 +1124,8 @@ display:
               editor_user: '0'
               admin_user: '0'
             placeholder: ''
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1161,6 +1176,8 @@ display:
               health_condition_supervisor_user: '0'
               driving_instructor_supervisor_user: '0'
             placeholder: ''
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1211,6 +1228,8 @@ display:
               health_condition_supervisor_user: '0'
               driving_instructor_supervisor_user: '0'
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1265,6 +1284,8 @@ display:
               health_condition_supervisor_user: '0'
               driving_instructor_supervisor_user: '0'
             reduce: true
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1316,6 +1337,8 @@ display:
               health_condition_supervisor_user: '0'
               driving_instructor_supervisor_user: '0'
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1940,6 +1963,8 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1977,6 +2002,8 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -2014,6 +2041,8 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -2065,6 +2094,8 @@ display:
               health_condition_supervisor_user: '0'
               driving_instructor_supervisor_user: '0'
             placeholder: ''
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -2110,6 +2141,8 @@ display:
               editor_user: '0'
               admin_user: '0'
             placeholder: ''
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -2160,6 +2193,8 @@ display:
               health_condition_supervisor_user: '0'
               driving_instructor_supervisor_user: '0'
             placeholder: ''
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -2210,6 +2245,8 @@ display:
               health_condition_supervisor_user: '0'
               driving_instructor_supervisor_user: '0'
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -2264,6 +2301,8 @@ display:
               health_condition_supervisor_user: '0'
               driving_instructor_supervisor_user: '0'
             reduce: true
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -2890,6 +2929,8 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -2927,6 +2968,8 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -2978,6 +3021,8 @@ display:
               health_condition_supervisor_user: '0'
               driving_instructor_supervisor_user: '0'
             placeholder: ''
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -3030,6 +3075,8 @@ display:
               health_condition_supervisor_user: '0'
               driving_instructor_supervisor_user: '0'
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -3082,6 +3129,8 @@ display:
               health_condition_supervisor_user: '0'
               driving_instructor_supervisor_user: '0'
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -3127,6 +3176,8 @@ display:
             placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -3170,6 +3221,8 @@ display:
             placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -3673,6 +3726,8 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -3710,6 +3765,8 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -3761,6 +3818,8 @@ display:
               health_condition_supervisor_user: '0'
               driving_instructor_supervisor_user: '0'
             placeholder: ''
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -3813,6 +3872,8 @@ display:
               health_condition_supervisor_user: '0'
               driving_instructor_supervisor_user: '0'
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -3865,6 +3926,8 @@ display:
               health_condition_supervisor_user: '0'
               driving_instructor_supervisor_user: '0'
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''

--- a/origins_workflow/config/optional/workflows.workflow.nics_editorial_workflow.yml
+++ b/origins_workflow/config/optional/workflows.workflow.nics_editorial_workflow.yml
@@ -1,4 +1,3 @@
-uuid: c0e58424-80ea-418b-bfd5-55ed7fce871a
 langcode: en
 status: true
 dependencies:

--- a/origins_workflow/config/optional/workflows.workflow.nics_editorial_workflow.yml
+++ b/origins_workflow/config/optional/workflows.workflow.nics_editorial_workflow.yml
@@ -1,3 +1,4 @@
+uuid: c0e58424-80ea-418b-bfd5-55ed7fce871a
 langcode: en
 status: true
 dependencies:
@@ -9,6 +10,11 @@ label: 'NICS Editorial Workflow'
 type: content_moderation
 type_settings:
   states:
+    archived:
+      published: false
+      default_revision: true
+      label: Archived
+      weight: 3
     draft:
       label: Draft
       published: false
@@ -25,12 +31,24 @@ type_settings:
       default_revision: true
       weight: 1
   transitions:
+    archive:
+      label: Archive
+      from:
+        - published
+      to: archived
+      weight: 3
     create_new_draft:
       label: 'Create New Draft'
       to: draft
       weight: -3
       from:
         - draft
+    draft_of_published:
+      label: 'Draft of Published'
+      from:
+        - published
+      to: draft
+      weight: 6
     publish:
       label: Publish
       to: published
@@ -49,6 +67,18 @@ type_settings:
         - needs_review
       to: draft
       weight: 0
+    restore:
+      label: Restore
+      from:
+        - archived
+      to: published
+      weight: 5
+    restore_to_draft:
+      label: 'Restore to Draft'
+      from:
+        - archived
+      to: draft
+      weight: 4
     submit_for_review:
       label: 'Submit for Review'
       from:

--- a/origins_workflow/config/optional/workflows.workflow.nics_editorial_workflow.yml
+++ b/origins_workflow/config/optional/workflows.workflow.nics_editorial_workflow.yml
@@ -2,9 +2,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - node.type.article
-    - node.type.news
-    - node.type.publication
   module:
     - content_moderation
 id: nics_editorial_workflow
@@ -66,7 +63,4 @@ type_settings:
       weight: 2
   entity_types:
     node:
-      - article
-      - news
-      - publication
   default_moderation_state: draft

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -200,3 +200,118 @@ function origins_workflow_menu_local_tasks_alter(&$data, $route_name) {
     unset($data['tabs'][1]['content_moderation.moderated_content']);
   }
 }
+
+/**
+ * Implements hook_preprocess_field().
+ */
+function origins_workflow_preprocess_field(&$variables) {
+  // Implement audit link.
+  if (isset($variables['element'])
+    && isset($variables['element']['#entity_type'])
+    && ($variables['element']['#entity_type'] == 'node')
+  ) {
+    // We are only interested in certain content types.
+    $content_type = $variables['element']['#bundle'];
+    $msg = NULL;
+    switch ($content_type) {
+      case 'health_condition':
+        $msg = _build_audit_link('health_condition', $variables);
+        break;
+
+      case 'article':
+      case 'contact':
+      case 'page':
+        $msg = _build_audit_link('article', $variables);
+        break;
+    }
+    if ($msg) {
+      // Send out 'needs audit' link as a Drupal warning message.
+      // N.B. This will only be visible if the 'System Messages'
+      // block is visible.
+      $this_route = \Drupal::routeMatch()->getRouteName();
+      // Do not show audit message on revisions page.
+      if ($this_route != 'diff.revisions_diff') {
+        \Drupal::messenger()->addWarning(t($msg->jsonSerialize()));
+        // Make sure that this page is not cached.
+        $variables['#cache'] = ['max-age' => 0];
+      }
+    }
+  }
+}
+
+/**
+ * Top level function to build audit links.
+ */
+function _build_audit_link($type, &$variables) {
+  // Only start this processing if the 'origins_workflow'
+  // module is installed.
+  if (Drupal::service('module_handler')->moduleExists('origins_workflow')) {
+    // Get the current node.
+    $node = Drupal::routeMatch()->getParameter('node');
+    if (!empty($node)) {
+      $nid = NULL;
+      if (is_object($node) && ($node instanceof NodeInterface)) {
+        $nid = $node->id();
+      }
+      elseif (is_string($node)) {
+        $nid = $node;
+        $node = Node::load($nid);
+      }
+      if (!empty($nid)) {
+        if ($type == 'health_condition') {
+          return _audit_link($type, $node->get('field_next_review_date')->value, $nid);
+        }
+        else {
+          // This will be an article, contact or page.
+          return _audit_link($type, $node->get('field_next_audit_due')->value, $nid);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Utility function to build the audit link html.
+ */
+function _audit_link($type, $dt, $nid) {
+  if (!empty($dt) && (strtotime($dt) < Drupal::time()->getCurrentTime())) {
+    // Next review date is in the past,
+    // so this node is due for audit - display node edit link
+    // (if the user is allowed to see it).
+    $account = User::load(Drupal::currentUser()->id());
+    if ($account->hasPermission('audit content')) {
+      // Retrieve audit text from config.
+      $audit_button_text = Drupal::config('origins_workflow.auditsettings')->get('audit_button_text');
+      $audit_button_hover_text = Drupal::config('origins_workflow.auditsettings')->get('audit_button_hover_text');
+      // Set up common attributes for links.
+      $options = [
+        'attributes' => [
+          'rel' => 'nofollow',
+          'title' => $audit_button_hover_text,
+          'class' => 'audit_link',
+        ],
+      ];
+      $link_object = NULL;
+      if ($type == 'health_condition') {
+        // For health conditions, just send the user to the node edit
+        // form, where they can set the 'next review date' to a date
+        // in the future to remove this node from the 'needs audit' view.
+        $link_object = Link::createFromRoute($audit_button_text, 'entity.node.edit_form', ['node' => $nid], $options);
+      }
+      else {
+        // For articles, contacts and pages send the user
+        // to the 'content audit' page.
+        $link_object = Link::createFromRoute($audit_button_text, 'origins_workflow.audit_controller_content_audit', ['nid' => $nid], $options);
+      }
+      if ($link_object) {
+        // Return rendered link.
+        $link_rendered = $link_object->toRenderable();
+        \Drupal::service('renderer')->renderRoot($link_rendered);
+        return $link_rendered['#markup'];
+      }
+      else {
+        return "";
+      }
+    }
+  }
+}

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -254,7 +254,8 @@ function _build_audit_link(&$variables) {
     if (!empty($nid)) {
       if ($node->hasField('field_next_audit_due')) {
         return _audit_link('field_next_audit_due', $node->get('field_next_audit_due')->value, $nid);
-      } elseif ($node->hasField('field_next_review_date')) {
+      }
+      elseif ($node->hasField('field_next_review_date')) {
         return _audit_link('field_next_review_date', $node->get('field_next_review_date')->value, $nid);
       }
     }

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -64,28 +64,6 @@ function origins_workflow_form_alter(&$form, FormStateInterface $form_state, $fo
   // Hide the audit date for everyone.
   if (isset($form['field_next_audit_due'])) {
     $form['field_next_audit_due']['#access'] = FALSE;
-    return;
-  }
-
-  // Node edit forms.
-  if (in_array($form_id, $edit_form_list)) {
-    $account = \Drupal::entityTypeManager()->getStorage('user')->load(\Drupal::currentUser()->id());
-    // Check user access level.
-    if ($account->hasRole('administrator')) {
-      // Admin can see audit date and change it.
-      $form['field_next_audit_due']['#access'] = TRUE;
-      $form['field_next_audit_due']['#disabled'] = FALSE;
-    }
-    elseif ($account->hasPermission('audit content')) {
-      // If user has permission to audit content but is not an admin
-      // then they can see the audit date but not change it.
-      $form['field_next_audit_due']['#access'] = TRUE;
-      $form['field_next_audit_due']['#disabled'] = TRUE;
-    }
-    else {
-      // Hide the audit date for anyone else.
-      $form['field_next_audit_due']['#access'] = FALSE;
-    }
   }
 
   // Tweak the published filter on the admin/content form.

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -10,6 +10,8 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\views\ViewExecutable;
 use Drupal\user\Entity\User;
+use Drupal\node\Entity\Node;
+use Drupal\Core\Link;
 
 /**
  * Implements hook_page_attachments().
@@ -243,28 +245,24 @@ function origins_workflow_preprocess_field(&$variables) {
  * Top level function to build audit links.
  */
 function _build_audit_link($type, &$variables) {
-  // Only start this processing if the 'origins_workflow'
-  // module is installed.
-  if (Drupal::service('module_handler')->moduleExists('origins_workflow')) {
-    // Get the current node.
-    $node = Drupal::routeMatch()->getParameter('node');
-    if (!empty($node)) {
-      $nid = NULL;
-      if (is_object($node) && ($node instanceof NodeInterface)) {
-        $nid = $node->id();
+  // Get the current node.
+  $node = Drupal::routeMatch()->getParameter('node');
+  if (!empty($node)) {
+    $nid = NULL;
+    if (is_object($node) && ($node instanceof Node)) {
+      $nid = $node->id();
+    }
+    elseif (is_string($node)) {
+      $nid = $node;
+      $node = Node::load($nid);
+    }
+    if (!empty($nid)) {
+      if ($type == 'health_condition') {
+        return _audit_link($type, $node->get('field_next_review_date')->value, $nid);
       }
-      elseif (is_string($node)) {
-        $nid = $node;
-        $node = Node::load($nid);
-      }
-      if (!empty($nid)) {
-        if ($type == 'health_condition') {
-          return _audit_link($type, $node->get('field_next_review_date')->value, $nid);
-        }
-        else {
-          // This will be an article, contact or page.
-          return _audit_link($type, $node->get('field_next_audit_due')->value, $nid);
-        }
+      else {
+        // This will be an article, contact or page.
+        return _audit_link($type, $node->get('field_next_audit_due')->value, $nid);
       }
     }
   }

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -214,17 +214,12 @@ function origins_workflow_preprocess_field(&$variables) {
   ) {
     // We are only interested in certain content types.
     $content_type = $variables['element']['#bundle'];
+    // Get a list of audited content types.
+    $config = \Drupal::config('origins_workflow.auditsettings');
+    $audit_types = $config->get('audit_content_types');
     $msg = NULL;
-    switch ($content_type) {
-      case 'health_condition':
-        $msg = _build_audit_link('health_condition', $variables);
-        break;
-
-      case 'article':
-      case 'contact':
-      case 'page':
-        $msg = _build_audit_link('article', $variables);
-        break;
+    if (in_array($content_type, $audit_types)) {
+      $msg = _build_audit_link($variables);
     }
     if ($msg) {
       // Send out 'needs audit' link as a Drupal warning message.
@@ -244,7 +239,7 @@ function origins_workflow_preprocess_field(&$variables) {
 /**
  * Top level function to build audit links.
  */
-function _build_audit_link($type, &$variables) {
+function _build_audit_link(&$variables) {
   // Get the current node.
   $node = Drupal::routeMatch()->getParameter('node');
   if (!empty($node)) {
@@ -257,12 +252,10 @@ function _build_audit_link($type, &$variables) {
       $node = Node::load($nid);
     }
     if (!empty($nid)) {
-      if ($type == 'health_condition') {
-        return _audit_link($type, $node->get('field_next_review_date')->value, $nid);
-      }
-      else {
-        // This will be an article, contact or page.
-        return _audit_link($type, $node->get('field_next_audit_due')->value, $nid);
+      if ($node->hasField('field_next_audit_due')) {
+        return _audit_link('field_next_audit_due', $node->get('field_next_audit_due')->value, $nid);
+      } elseif ($node->hasField('field_next_review_date')) {
+        return _audit_link('field_next_review_date', $node->get('field_next_review_date')->value, $nid);
       }
     }
   }
@@ -271,7 +264,7 @@ function _build_audit_link($type, &$variables) {
 /**
  * Utility function to build the audit link html.
  */
-function _audit_link($type, $dt, $nid) {
+function _audit_link($field, $dt, $nid) {
   if (!empty($dt) && (strtotime($dt) < Drupal::time()->getCurrentTime())) {
     // Next review date is in the past,
     // so this node is due for audit - display node edit link
@@ -290,15 +283,14 @@ function _audit_link($type, $dt, $nid) {
         ],
       ];
       $link_object = NULL;
-      if ($type == 'health_condition') {
-        // For health conditions, just send the user to the node edit
+      if ($field == 'field_next_review_date') {
+        // Just send the user to the node edit
         // form, where they can set the 'next review date' to a date
         // in the future to remove this node from the 'needs audit' view.
         $link_object = Link::createFromRoute($audit_button_text, 'entity.node.edit_form', ['node' => $nid], $options);
       }
       else {
-        // For articles, contacts and pages send the user
-        // to the 'content audit' page.
+        // Send the user to the 'content audit' page.
         $link_object = Link::createFromRoute($audit_button_text, 'origins_workflow.audit_controller_content_audit', ['nid' => $nid], $options);
       }
       if ($link_object) {


### PR DESCRIPTION
Changes required for Unity that will now be backported to NIDirect:

- Move auditing preprocess code out of NIDirect theme (see separate PR for theme https://github.com/dof-dss/nicsdru_nidirect_theme/pull/132) and into origins_workflow module as will be needed in all sites

- Remove preset content types from the workflow view so that it may be installed into any site (and also so that no content has to be deleted to enable workflow) 

- Remove tests for health condition content type (as that is NIDirect specific) and instead look for the fields 'field_next_audit_due' and 'field_next_review_date' and use that to drive the logic

- Improve README in origins_workflow