### PR TITLE
Add a utility module to standardise position of form element descriptions

### DIFF
--- a/origins_form_descriptions/css/form_descriptions.css
+++ b/origins_form_descriptions/css/form_descriptions.css
@@ -1,0 +1,6 @@
+/* Higher specificity than in form.css */
+.form-item div.description {
+  display: block;
+  margin-bottom: 0.5em;
+}
+

--- a/origins_form_descriptions/js/form_descriptions.js
+++ b/origins_form_descriptions/js/form_descriptions.js
@@ -1,0 +1,20 @@
+(function ($, Drupal) {
+  Drupal.behaviors.formDescriptions = {
+    attach: function attach (context) {
+      $('.description').each(function(){
+        // Find parent field ID, derive from the description id attribute.
+        const descId = $(this).attr('id');
+        const suffix = '--description';
+        const labelFor = descId.substr(0, descId.indexOf(suffix));
+
+        // Move element adjacent to it. The selector for this has to be
+        // a little greedy, because some elements vary their suffixes, but
+        // we do at least have a common prefix. Filter selects are fiddly,
+        // because they share almost the exact same label attribute values
+        // but we can use jQuery to only use the first label to avoid duplicates.
+        $('label[for^="' + labelFor + '"]').first().after($(this));
+      });
+    }
+  };
+})(jQuery, Drupal);
+

--- a/origins_form_descriptions/origins_form_descriptions.info.yml
+++ b/origins_form_descriptions/origins_form_descriptions.info.yml
@@ -1,0 +1,5 @@
+name: 'Origins Form Descriptions'
+type: module
+description: 'Moves the description on content form fields underneath the title'
+core: 8.x
+package: 'Origins'

--- a/origins_form_descriptions/origins_form_descriptions.libraries.yml
+++ b/origins_form_descriptions/origins_form_descriptions.libraries.yml
@@ -1,0 +1,9 @@
+form_descriptions:
+  css:
+    theme:
+      css/form_descriptions.css: {}
+  js:
+    js/form_descriptions.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupal

--- a/origins_form_descriptions/origins_form_descriptions.module
+++ b/origins_form_descriptions/origins_form_descriptions.module
@@ -8,18 +8,17 @@
 use Drupal\Core\Form\FormStateInterface;
 
 /**
- * Implements hook_form_alter().
+ * Implements hook_form_BASE_FORM_ID_alter().
  */
-function origins_form_descriptions_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  $route_name = \Drupal::routeMatch()->getRouteName();
+function origins_form_descriptions_form_node_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  $form['#attached']['library'][] = 'origins_form_descriptions/form_descriptions';
+}
 
-  // Add JS/CSS to entity add/edit and canonical forms.
-  if (preg_match('/^entity.\w+.edit_form$/', $route_name)
-    || preg_match('/^\w+.add$/', $route_name)
-      || preg_match('/^entity.\w+.canonical$/', $route_name)) {
-
-    $form['#attached']['library'][] = 'origins_form_descriptions/form_descriptions';
-  }
+/**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ */
+function origins_form_descriptions_form_media_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  $form['#attached']['library'][] = 'origins_form_descriptions/form_descriptions';
 }
 
 /**

--- a/origins_form_descriptions/origins_form_descriptions.module
+++ b/origins_form_descriptions/origins_form_descriptions.module
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @file
+ * Contains origins_form_descriptions.module.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_form_alter().
+ */
+function origins_form_descriptions_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  $route_name = \Drupal::routeMatch()->getRouteName();
+
+  // Add JS/CSS to entity add/edit and canonical forms.
+  if (preg_match('/^entity.\w+.edit_form$/', $route_name)
+    || preg_match('/^\w+.add$/', $route_name)
+      || preg_match('/^entity.\w+.canonical$/', $route_name)) {
+
+    $form['#attached']['library'][] = 'origins_form_descriptions/form_descriptions';
+  }
+}
+
+/**
+ * Implements hook_preprocess_form_element().
+ */
+function origins_form_descriptions_preprocess_form_element(&$variables) {
+  if (empty($variables['description']['attributes'])) {
+    return;
+  }
+
+  // Add a default hidden class to avoid visual jerkiness when loading.
+  $variables['description']['attributes']->addClass('js-hide');
+}


### PR DESCRIPTION
There is still a good number of inconsistencies with how Drupal core implements description positions using FAPI directives. See https://www.drupal.org/node/2318757 for the full conversation. This makes a current server side solution complex and brittle because of the wide variances in core and contrib modules.

This module provides a client-side solution that still needs to perform some careful DOM manipulation to work around some compound elements as well as the simple ones.

BEFORE:

![Screenshot 2020-06-16 at 13 45 22](https://user-images.githubusercontent.com/451261/84775983-a936ed00-afd7-11ea-9e9a-9fd292981281.png)

AFTER:

![Screenshot 2020-06-16 at 13 46 10](https://user-images.githubusercontent.com/451261/84776062-c10e7100-afd7-11ea-9ecc-778d3c13a4d2.png)
