### PR TITLE
Explicitly logout the user after each test

### DIFF
--- a/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/02.draftToNeedsReview.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/02.draftToNeedsReview.js
@@ -30,6 +30,10 @@ module.exports = {
       .click('input#edit-submit');
   },
 
+  after: function (browser) {
+    browser.drupalLogout();
+  },
+
   'Check moderation task options': browser => {
     // Click to open the moderation sidebar.
     browser.click('div.moderation-sidebar-toolbar-tab.toolbar-tab > a');

--- a/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/03.draftToQuickPublish.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/03.draftToQuickPublish.js
@@ -30,6 +30,10 @@ module.exports = {
       .click('input#edit-submit');
   },
 
+  after: function (browser) {
+    browser.drupalLogout();
+  },
+
   'Check moderation task options': browser => {
     // Click to open the moderation sidebar.
     browser.click('div.moderation-sidebar-toolbar-tab.toolbar-tab > a');

--- a/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/04.needsReviewToPublished.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/04.needsReviewToPublished.js
@@ -31,6 +31,10 @@ module.exports = {
       .click('input#edit-submit');
   },
 
+  after: function (browser) {
+    browser.drupalLogout();
+  },
+
   'Check moderation task options': browser => {
     // Check our sidebar label shows as 'needs review' before we begin.
     browser.click('div.moderation-sidebar-toolbar-tab.toolbar-tab > a')

--- a/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/05.needsReviewToReject.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/05.needsReviewToReject.js
@@ -31,6 +31,10 @@ module.exports = {
       .click('input#edit-submit');
   },
 
+  after: function (browser) {
+    browser.drupalLogout();
+  },
+
   'Check moderation task options': browser => {
     // Check our sidebar label shows as 'needs review' before we begin.
     browser.click('div.moderation-sidebar-toolbar-tab.toolbar-tab > a')

--- a/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/06.publishedToArchive.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/06.publishedToArchive.js
@@ -31,6 +31,10 @@ module.exports = {
       .click('input#edit-submit');
   },
 
+  after: function (browser) {
+    browser.drupalLogout();
+  },
+
   'Check moderation task buttons': browser => {
     // Check our sidebar label shows as 'published' before we begin.
     browser.click('div.moderation-sidebar-toolbar-tab.toolbar-tab > a')

--- a/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/07.publishedToDraftOfPublished.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/07.publishedToDraftOfPublished.js
@@ -31,6 +31,10 @@ module.exports = {
       .click('input#edit-submit');
   },
 
+  after: function (browser) {
+    browser.drupalLogout();
+  },
+
   'Check moderation task buttons': browser => {
     // Check our sidebar label shows as 'published' before we begin.
     browser.click('div.moderation-sidebar-toolbar-tab.toolbar-tab > a')

--- a/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/08.publishedToUnpublished.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/08.publishedToUnpublished.js
@@ -31,6 +31,10 @@ module.exports = {
       .click('input#edit-submit');
   },
 
+  after: function (browser) {
+    browser.drupalLogout();
+  },
+
   'Check moderation task buttons': browser => {
     // Check our sidebar label shows as 'published' before we begin.
     browser.click('div.moderation-sidebar-toolbar-tab.toolbar-tab > a')


### PR DESCRIPTION
Functional tests for Nightwatch indicate the NW admin user is logged in, triggering a failure. This PR aims to avoid this by explicitly logging out the current user after each test has run.

We should be able to see the effects overnight as the edge build takes the latest code and bundles it all together.