### PR TITLE
Add timestamp to node title to avoid tripping the unique title validation

### DIFF
--- a/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/02.draftToNeedsReview.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/02.draftToNeedsReview.js
@@ -17,7 +17,7 @@ module.exports = {
     browser.click('select[id="edit-field-subtheme-shs-0-0"]');
     browser.click('select[id="edit-field-subtheme-shs-0-0"] option[value="12"]');
     browser
-      .setValue('input#edit-title-0-value', ['Test article (draft to needs review)', browser.Keys.TAB])
+      .setValue('input#edit-title-0-value', [Date.now() + ' -- ' + 'Test article (draft to needs review)', browser.Keys.TAB])
       .pause(2000)
       .setValue('textarea#edit-field-summary-0-value', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.')
       .waitForElementVisible('#cke_edit-body-0-value', 2000)

--- a/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/03.draftToQuickPublish.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/03.draftToQuickPublish.js
@@ -17,7 +17,7 @@ module.exports = {
     browser.click('select[id="edit-field-subtheme-shs-0-0"]');
     browser.click('select[id="edit-field-subtheme-shs-0-0"] option[value="12"]');
     browser
-      .setValue('input#edit-title-0-value', ['Test article (draft to quick publish)', browser.Keys.TAB])
+      .setValue('input#edit-title-0-value', [Date.now() + ' -- ' + 'Test article (draft to quick publish)', browser.Keys.TAB])
       .pause(2000)
       .setValue('textarea#edit-field-summary-0-value', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.')
       .waitForElementVisible('#cke_edit-body-0-value', 2000)

--- a/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/04.needsReviewToPublished.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/04.needsReviewToPublished.js
@@ -18,7 +18,7 @@ module.exports = {
     browser.click('select[id="edit-field-subtheme-shs-0-0"] option[value="12"]');
     browser.click('select[id="edit-moderation-state-0-state"] option[value="needs_review"]');
     browser
-      .setValue('input#edit-title-0-value', ['Test article (needs review to published)', browser.Keys.TAB])
+      .setValue('input#edit-title-0-value', [Date.now() + ' -- ' + 'Test article (needs review to published)', browser.Keys.TAB])
       .pause(2000)
       .setValue('textarea#edit-field-summary-0-value', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.')
       .waitForElementVisible('#cke_edit-body-0-value', 2000)

--- a/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/05.needsReviewToReject.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/05.needsReviewToReject.js
@@ -18,7 +18,7 @@ module.exports = {
     browser.click('select[id="edit-field-subtheme-shs-0-0"] option[value="12"]');
     browser.click('select[id="edit-moderation-state-0-state"] option[value="needs_review"]');
     browser
-      .setValue('input#edit-title-0-value', ['Test article (needs review to reject)', browser.Keys.TAB])
+      .setValue('input#edit-title-0-value', [Date.now() + ' -- ' + 'Test article (needs review to reject)', browser.Keys.TAB])
       .pause(2000)
       .setValue('textarea#edit-field-summary-0-value', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.')
       .waitForElementVisible('#cke_edit-body-0-value', 2000)

--- a/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/06.publishedToArchive.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/06.publishedToArchive.js
@@ -18,7 +18,7 @@ module.exports = {
     browser.click('select[id="edit-field-subtheme-shs-0-0"] option[value="12"]');
     browser.click('select[id="edit-moderation-state-0-state"] option[value="published"]');
     browser
-      .setValue('input#edit-title-0-value', ['Test article (published to archive)', browser.Keys.TAB])
+      .setValue('input#edit-title-0-value', [Date.now() + ' -- ' + 'Test article (published to archive)', browser.Keys.TAB])
       .pause(2000)
       .setValue('textarea#edit-field-summary-0-value', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.')
       .waitForElementVisible('#cke_edit-body-0-value', 2000)

--- a/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/07.publishedToDraftOfPublished.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/07.publishedToDraftOfPublished.js
@@ -18,7 +18,7 @@ module.exports = {
     browser.click('select[id="edit-field-subtheme-shs-0-0"] option[value="12"]');
     browser.click('select[id="edit-moderation-state-0-state"] option[value="published"]');
     browser
-      .setValue('input#edit-title-0-value', ['Test article (published to draft of published)', browser.Keys.TAB])
+      .setValue('input#edit-title-0-value', [Date.now() + ' -- ' + 'Test article (published to draft of published)', browser.Keys.TAB])
       .pause(2000)
       .setValue('textarea#edit-field-summary-0-value', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.')
       .waitForElementVisible('#cke_edit-body-0-value', 2000)

--- a/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/08.publishedToUnpublished.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/moderationSidebar/08.publishedToUnpublished.js
@@ -18,7 +18,7 @@ module.exports = {
     browser.click('select[id="edit-field-subtheme-shs-0-0"] option[value="12"]');
     browser.click('select[id="edit-moderation-state-0-state"] option[value="published"]');
     browser
-      .setValue('input#edit-title-0-value', ['Test article (published to unpublished)', browser.Keys.TAB])
+      .setValue('input#edit-title-0-value', [Date.now() + ' -- ' + 'Test article (published to unpublished)', browser.Keys.TAB])
       .pause(2000)
       .setValue('textarea#edit-field-summary-0-value', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.')
       .waitForElementVisible('#cke_edit-body-0-value', 2000)


### PR DESCRIPTION
Helps fix the broken tests which can otherwise get stuck on the unique title per content type check.