### PR TITLE
D8 un 196

### DIFF
--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -118,7 +118,7 @@ function origins_workflow_hide_moderation_field(&$view) {
   // 'My Drafts' and 'All Drafts' displays.
   if (($view->element['#display_id'] === 'my_drafts') || ($view->element['#display_id'] === 'all_drafts')) {
     // Show the 'Change to Publish' field if the user has that permission.
-    if (isset($view->field['nothing_1']) && $account->hasPermission('use editorial transition publish')) {
+    if (isset($view->field['nothing_1']) && $account->hasPermission('use editorial transition quick_publish')) {
       $view->field['nothing_1']->options['exclude'] = TRUE;
     }
     elseif (isset($view->field['nothing'])) {

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -119,14 +119,20 @@ function origins_workflow_hide_moderation_field(&$view) {
   if (($view->element['#display_id'] === 'my_drafts') || ($view->element['#display_id'] === 'all_drafts')) {
     // Show the 'Change to Publish' field if the user has that permission.
     if (isset($view->field['nothing_1']) && $account->hasPermission('use editorial transition quick_publish')) {
+      // Show the 'nothing' custom text field which has links for 'Change to Draft' / 'Change to Needs Review'
+      // based on the current moderation state and always shows 'Change to Published'.
       $view->field['nothing_1']->options['exclude'] = TRUE;
       $view->field['nothing_2']->options['exclude'] = TRUE;
     }
     elseif (isset($view->field['nothing_1']) && $account->hasPermission('use editorial transition publish')) {
+      // Show the 'nothing_2' custom text field which has links for 'Change to Draft' and 'Change to Published'
+      // for nodes which have a state of 'Needs review'. For nodes in 'Draft' show 'Change to Needs Review'.
       $view->field['nothing_1']->options['exclude'] = TRUE;
       $view->field['nothing']->options['exclude'] = TRUE;
     }
     elseif (isset($view->field['nothing'])) {
+      // Show the 'nothing_1' custom text field which has links for 'Change to Draft' / 'Change to Needs Review'
+      // based on the current moderation state and does not have a  'Change to Published' link.
       $view->field['nothing']->options['exclude'] = TRUE;
       $view->field['nothing_2']->options['exclude'] = TRUE;
     }

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -120,9 +120,15 @@ function origins_workflow_hide_moderation_field(&$view) {
     // Show the 'Change to Publish' field if the user has that permission.
     if (isset($view->field['nothing_1']) && $account->hasPermission('use editorial transition quick_publish')) {
       $view->field['nothing_1']->options['exclude'] = TRUE;
+      $view->field['nothing_2']->options['exclude'] = TRUE;
+    }
+    elseif (isset($view->field['nothing_1']) && $account->hasPermission('use editorial transition publish')) {
+      $view->field['nothing_1']->options['exclude'] = TRUE;
+      $view->field['nothing']->options['exclude'] = TRUE;
     }
     elseif (isset($view->field['nothing'])) {
       $view->field['nothing']->options['exclude'] = TRUE;
+      $view->field['nothing_2']->options['exclude'] = TRUE;
     }
   }
 

--- a/origins_workflow/src/Controller/ModerationStateController.php
+++ b/origins_workflow/src/Controller/ModerationStateController.php
@@ -56,21 +56,58 @@ class ModerationStateController extends ControllerBase implements ContainerInjec
     // Load the entity.
     $entity = $this->entityTypeManager->getStorage('node')->load($nid);
     if ($entity) {
-      // Request the state change.
-      $entity->set('moderation_state', $new_state);
-      $entity->save();
-      // Log it.
-      $message = t('State of @title (nid @nid) changed to @new_state by @user', [
-        '@title' => $entity->getTitle(),
-        '@nid' => $nid,
-        '@new_state' => $new_state,
-        '@user' => $this->currentUser()->getAccountName(),
-      ]);
-      $this->logger->notice($message);
+      // See if this state change is allowed.
+      if ($this->transitionAllowed($entity, $new_state)) {
+        // Request the state change.
+        $entity->set('moderation_state', $new_state);
+        $entity->save();
+        // Log it.
+        $message = t('State of @title (nid @nid) changed to @new_state by @user', [
+          '@title' => $entity->getTitle(),
+          '@nid' => $nid,
+          '@new_state' => $new_state,
+          '@user' => $this->currentUser()->getAccountName(),
+        ]);
+        $this->logger->notice($message);
+      } else {
+        $message = t('State change of @title (nid @nid) to @new_state denied to @user', [
+          '@title' => $entity->getTitle(),
+          '@nid' => $nid,
+          '@new_state' => $new_state,
+          '@user' => $this->currentUser()->getAccountName(),
+        ]);
+        $this->logger->notice($message);
+      }
     }
     // Redirect user to current page (although the 'destination'
     // url argument will override this).
     return $this->redirect('view.workflow_moderation.needs_review');
+  }
+
+  /**
+   * Check user permission for state change.
+   */
+  private function transitionAllowed($entity, String $new_state) {
+    // Get the current moderation state.
+    $current_state = $entity->moderation_state->value;
+    // Check that we are looking at the latest revision.
+    if (!$entity->isLatestRevision()) {
+      $revision_ids = $this->entityTypeManager->getStorage('node')->revisionIds($entity);
+      $last_revision_id = end($revision_ids);
+      // Load the revision.
+      $last_revision = $this->entityTypeManager->getStorage('node')->loadRevision($last_revision_id);
+      $current_state = $last_revision->moderation_state->value;
+    }
+    // Check permissions of current user.
+    $current_user = $this->currentUser();
+    $transition_allowed = FALSE;
+    if (($current_state == 'draft') && ($new_state == 'published')) {
+      // Is this user allowed to use the 'quick publish' transition ?
+      if ($current_user->hasPermission('use editorial transition quick_publish')) {
+        $transition_allowed = TRUE;
+      }
+    }
+    return $transition_allowed;
   }
 
 }

--- a/origins_workflow/src/Controller/ModerationStateController.php
+++ b/origins_workflow/src/Controller/ModerationStateController.php
@@ -76,7 +76,7 @@ class ModerationStateController extends ControllerBase implements ContainerInjec
           '@new_state' => $new_state,
           '@user' => $this->currentUser()->getAccountName(),
         ]);
-        $this->logger->notice($message);
+        $this->logger->error($message);
       }
     }
     // Redirect user to current page (although the 'destination'
@@ -104,6 +104,18 @@ class ModerationStateController extends ControllerBase implements ContainerInjec
     if (($current_state == 'draft') && ($new_state == 'published')) {
       // Is this user allowed to use the 'quick publish' transition ?
       if ($current_user->hasPermission('use editorial transition quick_publish')) {
+        $transition_allowed = TRUE;
+      }
+    } else if (($current_state == 'draft') && ($new_state == 'needs_review')) {
+      if ($current_user->hasPermission('use editorial transition submit_for_review')) {
+        $transition_allowed = TRUE;
+      }
+    } else if (($current_state == 'needs_review') && ($new_state == 'draft')) {
+      if ($current_user->hasPermission('use editorial transition reject')) {
+        $transition_allowed = TRUE;
+      }
+    } else if (($current_state == 'needs_review') && ($new_state == 'published')) {
+      if ($current_user->hasPermission('use editorial transition publish')) {
         $transition_allowed = TRUE;
       }
     }

--- a/origins_workflow/src/Controller/ModerationStateController.php
+++ b/origins_workflow/src/Controller/ModerationStateController.php
@@ -69,7 +69,8 @@ class ModerationStateController extends ControllerBase implements ContainerInjec
           '@user' => $this->currentUser()->getAccountName(),
         ]);
         $this->logger->notice($message);
-      } else {
+      }
+      else {
         $message = t('State change of @title (nid @nid) to @new_state denied to @user', [
           '@title' => $entity->getTitle(),
           '@nid' => $nid,
@@ -106,15 +107,18 @@ class ModerationStateController extends ControllerBase implements ContainerInjec
       if ($current_user->hasPermission('use editorial transition quick_publish')) {
         $transition_allowed = TRUE;
       }
-    } else if (($current_state == 'draft') && ($new_state == 'needs_review')) {
+    }
+    elseif (($current_state == 'draft') && ($new_state == 'needs_review')) {
       if ($current_user->hasPermission('use editorial transition submit_for_review')) {
         $transition_allowed = TRUE;
       }
-    } else if (($current_state == 'needs_review') && ($new_state == 'draft')) {
+    }
+    elseif (($current_state == 'needs_review') && ($new_state == 'draft')) {
       if ($current_user->hasPermission('use editorial transition reject')) {
         $transition_allowed = TRUE;
       }
-    } else if (($current_state == 'needs_review') && ($new_state == 'published')) {
+    }
+    elseif (($current_state == 'needs_review') && ($new_state == 'published')) {
       if ($current_user->hasPermission('use editorial transition publish')) {
         $transition_allowed = TRUE;
       }


### PR DESCRIPTION
- User must have 'quick publish' permission to publish from 'drafts' or 'all drafts' view
- The 'change state' controller now checks permissions also so that URLs cannot be 'manufactured' to publish content illegally

Relates to https://github.com/dof-dss/nicsdru_unity/pull/209 (corresponding view change in Uregni)
(Will also require a corresponding view change in NIDirect)