### PR TITLE
D8NID-936

### DIFF
--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -321,7 +321,18 @@ function origins_workflow_preprocess_table(&$variables) {
           // might come along.
           $title_text = $title_markup->getUntranslatedString();
           if (($title_text == 'Set as current revision') || ($title_text == 'Revert')) {
-            $variables['rows'][$idx]['cells'][$action_column]['content']['#links']['revert']['title'] = t('Copy to new revision');
+            // Change the URL to our controller so we're creating a new draft of the revision selected,
+            // rather than reverting to that revision + it's publish state.
+            $revert_link = &$variables['rows'][$idx]['cells'][$action_column]['content']['#links']['revert'];
+            $revert_link['title'] = t('Copy to new revision');
+            // Need to add a destination query parameter to override the redirect in the controller.
+            $revert_link['url'] = Url::fromRoute('origins_workflow.moderation_state_controller_change_state',
+              [
+                'nid' => \Drupal::routeMatch()->getParameter('node')->id(),
+                'new_state' => 'draft'
+              ],
+              ['query' => ['destination' => \Drupal::request()->getPathInfo()]]
+            );
           }
         }
       }

--- a/origins_workflow/src/Controller/ModerationStateController.php
+++ b/origins_workflow/src/Controller/ModerationStateController.php
@@ -123,6 +123,11 @@ class ModerationStateController extends ControllerBase implements ContainerInjec
         $transition_allowed = TRUE;
       }
     }
+    elseif (($current_state == 'published') && ($new_state == 'draft')) {
+      if ($current_user->hasPermission('use editorial transition draft_of_published')) {
+        $transition_allowed = TRUE;
+      }
+    }
     return $transition_allowed;
   }
 


### PR DESCRIPTION
Gently extends the transitions in our controller class so that a revision that was previously published can now move back to draft, using the existing draft_of_published transition.

This differs from core, because in core 'Revert' reverts both the content and publish state to the current revision. Here, we only want the content in a new revision and it should become a draft for editorial checking before being published.