### PR TITLE
D8NID-1011

### DIFF
--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -6,7 +6,9 @@
  */
 
 use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\RevisionLogInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
@@ -43,6 +45,15 @@ function origins_workflow_entity_presave(EntityInterface $entity) {
         }
       }
     }
+  }
+
+  // Processing to alter revision log messages.
+  if ($entity instanceof ContentEntityInterface && $entity instanceof RevisionLogInterface) {
+    $x = $entity->getRevisionLogMessage();
+    $source_revision_id = $entity->getLoadedRevisionId();
+    $entity->setRevisionLogMessage(t('Copy of revision @rev', [
+      '@rev' => $source_revision_id,
+    ]));
   }
 }
 

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -47,9 +47,8 @@ function origins_workflow_entity_presave(EntityInterface $entity) {
     }
   }
 
-  // Processing to alter revision log messages.
+  // Processing to alter revision log messages and include the revision number.
   if ($entity instanceof ContentEntityInterface && $entity instanceof RevisionLogInterface) {
-    $x = $entity->getRevisionLogMessage();
     $source_revision_id = $entity->getLoadedRevisionId();
     $entity->setRevisionLogMessage(t('Copy of revision @rev', [
       '@rev' => $source_revision_id,


### PR DESCRIPTION
Override the revision log message that comes from Drupal core so that the revision number is included.

(This ticket is linked to https://github.com/dof-dss/nicsdru_origins_modules/pull/113 which has already been merged)