### PR TITLE
Revision workflow fix

### DIFF
--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -347,15 +347,6 @@ function origins_workflow_preprocess_table(&$variables) {
         if (isset($this_url)) {
           $this_version = $this_url->getRouteParameters()['node_revision'];
         }
-        // Change the link text from 'Set as current revision' to
-        // 'Copy to new revision' as it makes more sense - see issue
-        // https://www.drupal.org/project/drupal/issues/2899719
-        if (isset($variables['rows'][$idx]['cells'][$action_column]['content']['#links']['revert']['title'])) {
-          $title_markup = $variables['rows'][$idx]['cells'][$action_column]['content']['#links']['revert']['title'];
-          // Check the existing text in an attempt to detect any core fix that
-          // might come along.
-          $title_text = $title_markup->getUntranslatedString();
-        }
       }
       else {
         // There is no 'revert' button in this row, therefore it must be the

--- a/origins_workflow/tests/src/Nightwatch/Tests/RevisionTest.js
+++ b/origins_workflow/tests/src/Nightwatch/Tests/RevisionTest.js
@@ -10,13 +10,6 @@ module.exports = {
       .expect.element('h1.page-title')
       .text.to.contain('Revisions for');
 
-    /* Test that 'Copy to new revision' link has been inserted
-    *  by origins_workflow_preprocess_table() */
-    browser
-      .useXpath()
-      .expect.element('//table//td[5]//div//div//ul//li//a')
-      .text.to.contain('Copy to new revision');
-
     /* Test that link text has been overridden with
     * 'Create Draft of Published' by origins_workflow_preprocess_table() */
     browser


### PR DESCRIPTION
- change Nightwatch test as 'Copy to new revision' functionality has now been removed
- remove redundant code