### PR TITLE
Replace JS solution for media library widgets due to crash issues

### DIFF
--- a/origins_form_descriptions/js/form_descriptions.js
+++ b/origins_form_descriptions/js/form_descriptions.js
@@ -13,9 +13,6 @@
         // because they share almost the exact same label attribute values
         // but we can use jQuery to only use the first label to avoid duplicates.
         $('label[for^="' + labelFor + '"]').first().after($(this));
-
-        // Move descriptions in fieldsets after the legend.
-        $('fieldset[aria-describedby="' + descId + '"] legend').after($(this));
       });
     }
   };

--- a/origins_form_descriptions/origins_form_descriptions.info.yml
+++ b/origins_form_descriptions/origins_form_descriptions.info.yml
@@ -3,3 +3,5 @@ type: module
 description: 'Moves the description on content form fields underneath the title'
 core: 8.x
 package: 'Origins'
+dependencies:
+  - drupal:media_library

--- a/origins_form_descriptions/origins_form_descriptions.module
+++ b/origins_form_descriptions/origins_form_descriptions.module
@@ -39,3 +39,12 @@ function origins_form_descriptions_preprocess_form_element(&$variables) {
   // Add a default hidden class to avoid visual jerkiness when loading.
   $variables['description']['attributes']->addClass('js-hide');
 }
+
+/**
+ * Implements hook_theme_registry_alter
+ */
+function origins_form_descriptions_theme_registry_alter(&$theme_registry) {
+  if (\Drupal::service('router.admin_context')->isAdminRoute()) {
+    $theme_registry['fieldset__media_library_widget']['path'] = drupal_get_path('module', 'origins_form_descriptions') . '/templates/media-library';
+  }
+}

--- a/origins_form_descriptions/templates/media-library/fieldset--media-library-widget.html.twig
+++ b/origins_form_descriptions/templates/media-library/fieldset--media-library-widget.html.twig
@@ -1,0 +1,64 @@
+{#
+/**
+ * @file
+ * Theme override for the media library widget.
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the fieldset element.
+ * - errors: (optional) Any errors for this fieldset element, may not be set.
+ * - required: Boolean indicating whether the fieldeset element is required.
+ * - legend: The legend element containing the following properties:
+ *   - title: Title of the fieldset, intended for use as the text of the legend.
+ *   - attributes: HTML attributes to apply to the legend.
+ * - description: The description element containing the following properties:
+ *   - content: The description content of the fieldset.
+ *   - attributes: HTML attributes to apply to the description container.
+ * - children: The rendered child elements of the fieldset.
+ * - prefix: The content to add before the fieldset children.
+ * - suffix: The content to add after the fieldset children.
+ *
+ * @see seven_preprocess_fieldset__media_library_widget()
+ * @see template_preprocess_fieldset()
+ */
+#}
+{%
+  set classes = [
+    'js-form-item',
+    'form-item',
+    'js-form-wrapper',
+    'form-wrapper',
+    'media-library-widget',
+  ]
+%}
+<fieldset{{ attributes.addClass(classes) }}>
+  {%
+    set legend_span_classes = [
+      'fieldset-legend',
+      required ? 'js-form-required',
+      required ? 'form-required',
+    ]
+  %}
+  {#  Always wrap fieldset legends in a <span> for CSS positioning. #}
+  <legend{{ legend.attributes }}>
+    <span{{ legend_span.attributes.addClass(legend_span_classes) }}>{{ legend.title }}</span>
+  </legend>
+  {% if description.content %}
+    <div{{ description.attributes.addClass('description') }}>{{ description.content }}</div>
+  {% endif %}
+  <div class="fieldset-wrapper">
+    {% if errors %}
+      <div class="form-item--error-message">
+        <strong>{{ errors }}</strong>
+      </div>
+    {% endif %}
+    {% if prefix.empty_selection %}
+      <p class="media-library-widget-empty-text">{{ prefix.empty_selection }}</p>
+    {% elseif prefix.weight_toggle %}
+      {{ prefix.weight_toggle }}
+    {% endif %}
+    {{ children }}
+    {% if suffix %}
+      <span class="field-suffix">{{ suffix }}</span>
+    {% endif %}
+  </div>
+</fieldset>


### PR DESCRIPTION
Replaced with server-side template which explicitly moves the description element into the correct place. Module override to steal template control from the core media library widget and overall much less likely to cause drastic JS crashes when combined with server-side AJAX callbacks.