### PR TITLE
D8UN-286 Update from => to function to resolve errors in IE11

### DIFF
--- a/origins_workflow/js/moderation_sidebar_fix.js
+++ b/origins_workflow/js/moderation_sidebar_fix.js
@@ -4,7 +4,7 @@
  */
 (function ($, Drupal) {
   Drupal.behaviors.landinglisting = {
-    attach: (context) => {
+    attach: function (context) {
       $("a.archive-link").click(function(event) {
         /*
         A class of 'archive-link' means that this link has been faked by code in


### PR DESCRIPTION
The use of `attach: (context) =>` instead of `attach: function (context)` was causing javascript errors on pages with sidebar moderation in IE11.