### PR TITLE
Add image mime types to service, preprocess media library view

### DIFF
--- a/origins_media/origins_media.module
+++ b/origins_media/origins_media.module
@@ -5,11 +5,10 @@
  * Contains origins_media.module.
  */
 
-use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
+use Drupal\file\Entity\File;
 use Drupal\file\FileInterface;
 use Drupal\media\MediaInterface;
 use Drupal\views\Render\ViewsRenderPipelineMarkup;
@@ -163,7 +162,24 @@ function origins_media_preprocess_views_view_field(&$variables) {
 
     if ($field_id == 'filemime') {
       $pretty_mimes = \Drupal::service('origins_media.pretty_mime_types')->getMimeTypes();
-      $mime_type_key = $variables['output']->__toString();
+      $mime_type_key = '';
+
+      if (empty($variables['output'])) {
+        // If empty, try checking mime type for an image.
+        $media = $variables['row']->_entity;
+
+        if ($media instanceof MediaInterface && $media->bundle() == 'image') {
+          // Need to load the file behind it to check what it is.
+          $file = File::load($media->field_media_image->target_id);
+
+          if ($file instanceof FileInterface) {
+            $mime_type_key = $file->getMimeType();
+          }
+        }
+      }
+      else {
+        $mime_type_key = $variables['output']->__toString();
+      }
 
       // Replace with prettier version.
       $variables['output'] = ViewsRenderPipelineMarkup::create($pretty_mimes[$mime_type_key]);

--- a/origins_media/src/PrettyMimes.php
+++ b/origins_media/src/PrettyMimes.php
@@ -25,6 +25,11 @@ class PrettyMimes {
       'application/vnd.oasis.opendocument.spreadsheet' => 'OpenDocument spreadsheet',
       'application/vnd.oasis.opendocument.presentation' => 'OpenDocument presentation',
       'application/zip' => 'ZIP archive',
+      'image/jpeg' => 'JPEG image',
+      'image/jpg' => 'JPG image',
+      'image/gif' => 'GIF image',
+      'image/png' => 'PNG image',
+      'image/svg+xml' => 'SVG image',
       'text/csv' => 'Comma-separated values',
       'text/html' => 'HTML (HyperText Markup Language)',
     ];


### PR DESCRIPTION
Mimetype for the file needs a different relationship. The media view uses a File entity for documents etc but need to look at the image file for image media entities and rewrite the output accordingly.