### PR TITLE
D8NID-1134: Audit this published content theming

### DIFF
--- a/origins_workflow/config/install/origins_workflow.auditsettings.yml
+++ b/origins_workflow/config/install/origins_workflow.auditsettings.yml
@@ -1,6 +1,7 @@
-audit_button_text: 'Audit this published content'
-audit_button_hover_text: 'Click this link to indicate you have checked this content for accuracy and relevance'
-audit_confirmation_text: 'Click this button to indicate that you have audited this published content and are happy that it is still accurate and relevant.'
+audit_text: 'This published content requires an audit to ensure it is still accurate and relevant.'
+audit_button_text: 'Audit required — this published content requires an audit to ensure it is still accurate and relevant'
+audit_button_hover_text: ''
+audit_confirmation_text: 'Review the content and select "Audit complete" if the content is still accurate and relevant.'
 audit_content_types:
   article: article
   news: 0

--- a/origins_workflow/css/admin.css
+++ b/origins_workflow/css/admin.css
@@ -5,3 +5,7 @@
 body.path-admin form.views-exposed-form div.chosen-drop ul.chosen-results li.group-result {
   display: none;
 }
+
+.origins-audit-actions .button {
+  margin: .5em !important;
+}

--- a/origins_workflow/origins_workflow.libraries.yml
+++ b/origins_workflow/origins_workflow.libraries.yml
@@ -1,3 +1,8 @@
+origins_workflow.dialogs:
+  dependencies:
+    - core/jquery
+    - core/drupal.dialog.ajax
+    - core/jquery.form
 admin.css:
   css:
     theme:

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -23,6 +23,8 @@ use Drupal\workflows\TransitionInterface;
  * Implements hook_page_attachments().
  */
 function origins_workflow_page_attachments(array &$attachments) {
+  // Attach library for dialogs.
+  $attachments['#attached']['library'][] = 'origins_workflow/origins_workflow.dialogs';
   // Attach extra custom css for admin menu.
   $attachments['#attached']['library'][] = 'origins_workflow/admin.css';
 }
@@ -274,7 +276,7 @@ function _audit_link($field, $dt, $nid) {
         'attributes' => [
           'rel' => 'nofollow',
           'title' => $audit_button_hover_text,
-          'class' => 'audit_link',
+          'class' => ['audit_link'],
         ],
       ];
       $link_object = NULL;
@@ -285,7 +287,10 @@ function _audit_link($field, $dt, $nid) {
         $link_object = Link::createFromRoute($audit_button_text, 'entity.node.edit_form', ['node' => $nid], $options);
       }
       else {
-        // Send the user to the 'content audit' page.
+        // Open 'content audit' page in an off-canvas dialog.
+        $options['attributes']['class'][] = 'use-ajax';
+        $options['attributes']['data-dialog-renderer'][] = 'off_canvas';
+        $options['attributes']['data-dialog-type'][] = 'dialog';
         $link_object = Link::createFromRoute($audit_button_text, 'origins_workflow.audit_controller_content_audit', ['nid' => $nid], $options);
       }
       if ($link_object) {

--- a/origins_workflow/src/Controller/AuditController.php
+++ b/origins_workflow/src/Controller/AuditController.php
@@ -76,34 +76,40 @@ class AuditController extends ControllerBase implements ContainerInjectionInterf
       $node = $this->entityTypeManager()->getStorage('node')->load($nid);
       if ($node) {
         // Retrieve audit text from config.
-        $audit_button_text = $this->config('origins_workflow.auditsettings')->get('audit_button_text');
         $audit_confirmation_text = $this->config('origins_workflow.auditsettings')->get('audit_confirmation_text');
         // Show confirmation text to user.
-        $render_array['confirmation_text'] = [
+        $render_array['origins_audit_text'] = [
           '#markup' => $this->t($audit_confirmation_text),
-          '#prefix' => "<div class='confirmation_text'>",
-          '#suffix' => "</div>",
+          '#prefix' => "<p class='confirmation_text'>",
+          '#suffix' => "</p>",
           '#weight' => 0,
         ];
-        // Build a confirm link.
-        $render_array['link1'] = [
-          '#title' => $this->t($audit_button_text),
-          '#type' => 'link',
-          '#url' => Url::fromRoute('origins_workflow.audit_controller_confirm_audit', ['nid' => $nid]),
-          '#attributes' => ['rel' => 'nofollow', 'class' => 'audit_link'],
-          '#prefix' => "<span class='confirm_audit'>",
-          '#suffix' => "</span>",
-          '#weight' => 1,
-        ];
-        // Build a cancel link.
-        $render_array['link2'] = [
-          '#title' => $this->t('Cancel'),
-          '#type' => 'link',
-          '#url' => Url::fromRoute('entity.node.canonical', ['node' => $nid]),
-          '#attributes' => ['rel' => 'nofollow', 'class' => 'cancel_link'],
-          '#prefix' => "<span class='cancel'>",
-          '#suffix' => "</span>",
-          '#weight' => 2,
+        // Build confirmation actions.
+        $render_array['origins_audit_actions'] = [
+          '#type' => 'container',
+          '#attributes' => [
+            'class' => 'origins-audit-actions',
+          ],
+          'origins_audit_confirm' => [
+            '#title' => $this->t('Audit complete'),
+            '#type' => 'link',
+            '#url' => Url::fromRoute('origins_workflow.audit_controller_confirm_audit', ['nid' => $nid]),
+            '#attributes' => [
+              'rel' => 'nofollow',
+              'class' => ['submit', 'button', 'button--primary']
+            ],
+            '#weight' => 1,
+          ],
+          'origins_audit_cancel' => [
+            '#title' => $this->t('Cancel'),
+            '#type' => 'link',
+            '#url' => Url::fromRoute('entity.node.canonical', ['node' => $nid]),
+            '#attributes' => [
+              'rel' => 'nofollow',
+              'class' => ['submit', 'button']
+            ],
+            '#weight' => 2,
+          ],
         ];
       }
     }


### PR DESCRIPTION
- Open audit content link in off_canvas dialog
- Changes to audit text and markup
- Style confirmation links as buttons

<img width="1370" alt="Screenshot 2021-03-21 at 16 43 09" src="https://user-images.githubusercontent.com/52457988/111995785-3bdd5d00-8b11-11eb-9e9e-df52f455a51c.png">
