### PR TITLE
Adjust route permissions so editors can't see the core taxonomy routes

### DIFF
--- a/origins_common/origins_common.services.yml
+++ b/origins_common/origins_common.services.yml
@@ -1,0 +1,5 @@
+services:
+  origins_common.route_subscriber:
+    class: Drupal\origins_common\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/origins_common/src/Routing/RouteSubscriber.php
+++ b/origins_common/src/Routing/RouteSubscriber.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\origins_common\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    if ($route = $collection->get('entity.taxonomy_vocabulary.collection')) {
+      $route->setRequirement('_permission', 'administer taxonomy');
+    }
+  }
+
+}


### PR DESCRIPTION
Only roles with the administer taxonomy permission should see it. This ensures no confusion or crossover with the taxonomy_navigator module.