### PR TITLE
D8NID-1141

### DIFF
--- a/origins_workflow/origins_workflow.install
+++ b/origins_workflow/origins_workflow.install
@@ -13,6 +13,11 @@ use Drupal\user\Entity\User;
  * Perform actions to set up the site for this module.
  */
 function origins_workflow_install() {
+  // Assign a weight 1 higher than pathauto to ensure that alias
+  // handling in origins_workflow_entity_update is not negated
+  // by post save processing in pathauto.
+  module_set_weight('origins_workflow', 2);
+
   // Assign user 1 the "administrator" role.
   $user = User::load(1);
   $user->roles[] = 'administrator';

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -91,10 +91,19 @@ function origins_workflow_form_alter(&$form, FormStateInterface $form_state, $fo
  * Implements hook_form_BASE_FORM_ID_alter().
  */
 function origins_workflow_form_node_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Add an extra validator to the node edit form.
   array_unshift($form['#validate'], '_origins_workflow_validate_path_alias');
 }
 
+/**
+ * Provide extra validation for node edit form.
+ */
 function _origins_workflow_validate_path_alias(&$form, FormStateInterface $form_state) {
+  // If this node has its moderation state set to 'archived' then make sure
+  // that 'generate automatic alias' is un-checked and that the 'URL alias'
+  // field is empty. This will make sure that there is no alias and hence
+  // it will be possible to create a redirect to a replacement node if
+  // necessary.
   if ($form_state->getValue('moderation_state')[0]['value'] == 'archived') {
     $path_alias_settings = $form_state->getValue('path');
     $path_alias_settings[0]['alias'] = '';

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -88,6 +88,37 @@ function origins_workflow_form_alter(&$form, FormStateInterface $form_state, $fo
 }
 
 /**
+ * Implements hook_entity_update().
+ */
+function origins_workflow_entity_update(EntityInterface $entity) {
+  // Identify nodes being archived.
+  if ($entity->moderation_state->value == 'archived') {
+    if ($entity->original->moderation_state->value == 'published') {
+      // This node is being archived, so we need to delete the alias (which
+      // will enable us to create redirects if we want to).
+      $actual_alias = \Drupal::service('path.alias_manager')->getAliasByPath('/node/' . $entity->content_entity_id->value);
+      // Get all aliases attached to this node.
+      $path_alias_storage = \Drupal::entityTypeManager()->getStorage('path_alias');
+      $alias_objects = $path_alias_storage->loadByProperties([
+        'path' => '/node/' . $entity->content_entity_id->value,
+        'langcode' => $entity->language()->getId()
+      ]);
+      $path_alias_storage->delete($alias_objects);
+      $alias_manager = \Drupal::service('path_alias.manager');
+      $alias_manager->cacheClear();
+      /*foreach ($alias_objects as $alias_object) {
+        // We could delete all aliases here, but for now we'll just delete the main one.
+        if ($alias_object->alias->value == $actual_alias) {
+          // Delete the main alias.
+          $path_alias_storage->delete([$alias_object]);
+          //$alias_object->delete();
+        }
+      }*/
+    }
+  }
+}
+
+/**
  * Implements hook_menu_links_discovered_alter().
  */
 function origins_workflow_menu_links_discovered_alter(&$links) {

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -138,6 +138,37 @@ function _origins_workflow_validate_term_path_alias(&$form, FormStateInterface $
 }
 
 /**
+ * Implements hook_entity_update().
+ */
+function origins_workflow_entity_update(EntityInterface $entity) {
+  // Identify nodes being archived.
+  if ($entity->moderation_state->value == 'archived') {
+    if ($entity->original->moderation_state->value == 'published') {
+      // This node is being archived, so we need to delete the alias (which
+      // will enable us to create redirects if we want to).
+      $actual_alias = \Drupal::service('path.alias_manager')->getAliasByPath('/node/' . $entity->nid->value);
+      // Get all aliases attached to this node.
+      $path_alias_storage = \Drupal::entityTypeManager()->getStorage('path_alias');
+      $alias_objects = $path_alias_storage->loadByProperties([
+        'path' => '/node/' . $entity->nid->value,
+        'langcode' => $entity->language()->getId()
+      ]);
+      $path_alias_storage->delete($alias_objects);
+      $alias_manager = \Drupal::service('path_alias.manager');
+      $alias_manager->cacheClear('/node/' . $entity->nid->value);
+      /*foreach ($alias_objects as $alias_object) {
+        // We could delete all aliases here, but for now we'll just delete the main one.
+        if ($alias_object->alias->value == $actual_alias) {
+          // Delete the main alias.
+          $path_alias_storage->delete([$alias_object]);
+          //$alias_object->delete();
+        }
+      }*/
+    }
+  }
+}
+
+/**
  * Implements hook_menu_links_discovered_alter().
  */
 function origins_workflow_menu_links_discovered_alter(&$links) {

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -88,33 +88,18 @@ function origins_workflow_form_alter(&$form, FormStateInterface $form_state, $fo
 }
 
 /**
- * Implements hook_entity_update().
+ * Implements hook_form_BASE_FORM_ID_alter().
  */
-function origins_workflow_entity_update(EntityInterface $entity) {
-  // Identify nodes being archived.
-  if ($entity->moderation_state->value == 'archived') {
-    if ($entity->original->moderation_state->value == 'published') {
-      // This node is being archived, so we need to delete the alias (which
-      // will enable us to create redirects if we want to).
-      $actual_alias = \Drupal::service('path.alias_manager')->getAliasByPath('/node/' . $entity->content_entity_id->value);
-      // Get all aliases attached to this node.
-      $path_alias_storage = \Drupal::entityTypeManager()->getStorage('path_alias');
-      $alias_objects = $path_alias_storage->loadByProperties([
-        'path' => '/node/' . $entity->content_entity_id->value,
-        'langcode' => $entity->language()->getId()
-      ]);
-      $path_alias_storage->delete($alias_objects);
-      $alias_manager = \Drupal::service('path_alias.manager');
-      $alias_manager->cacheClear();
-      /*foreach ($alias_objects as $alias_object) {
-        // We could delete all aliases here, but for now we'll just delete the main one.
-        if ($alias_object->alias->value == $actual_alias) {
-          // Delete the main alias.
-          $path_alias_storage->delete([$alias_object]);
-          //$alias_object->delete();
-        }
-      }*/
-    }
+function origins_workflow_form_node_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  array_unshift($form['#validate'], '_origins_workflow_validate_path_alias');
+}
+
+function _origins_workflow_validate_path_alias(&$form, FormStateInterface $form_state) {
+  if ($form_state->getValue('moderation_state')[0]['value'] == 'archived') {
+    $path_alias_settings = $form_state->getValue('path');
+    $path_alias_settings[0]['alias'] = '';
+    $path_alias_settings[0]['pathauto'] = 0;
+    $form_state->setValue('path', $path_alias_settings);
   }
 }
 

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -113,6 +113,31 @@ function _origins_workflow_validate_path_alias(&$form, FormStateInterface $form_
 }
 
 /**
+ * Implements hook_form_taxonomy_term_form_alter().
+ */
+function origins_workflow_form_taxonomy_term_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Add an extra validator to the term edit form.
+  array_unshift($form['#validate'], '_origins_workflow_validate_term_path_alias');
+}
+
+/**
+ * Provide extra validation for taxonomy term edit form.
+ */
+function _origins_workflow_validate_term_path_alias(&$form, FormStateInterface $form_state) {
+  // If this node has its moderation state set to 'archived' then make sure
+  // that 'generate automatic alias' is un-checked and that the 'URL alias'
+  // field is empty. This will make sure that there is no alias and hence
+  // it will be possible to create a redirect to a replacement node if
+  // necessary.
+  if ($form_state->getValue('status')['value'] == 0) {
+    $path_alias_settings = $form_state->getValue('path');
+    $path_alias_settings[0]['alias'] = '';
+    $path_alias_settings[0]['pathauto'] = 0;
+    $form_state->setValue('path', $path_alias_settings);
+  }
+}
+
+/**
  * Implements hook_menu_links_discovered_alter().
  */
 function origins_workflow_menu_links_discovered_alter(&$links) {

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -141,7 +141,12 @@ function _origins_workflow_validate_term_path_alias(&$form, FormStateInterface $
  * Implements hook_entity_update().
  */
 function origins_workflow_entity_update(EntityInterface $entity) {
-  // Identify nodes being archived.
+  // Note that this will only work if the module weighting of the
+  // origins_workflow module is higher than that of the 'pathauto'
+  // module. This is because the hook_entity_update in 'pathauto'
+  // re-creates the alias, and the code in here deletes it !
+  // We want the alias deletion to run last so that it really
+  // is deleted.
   if (($entity->moderation_state->value == 'archived')
     && ($entity->original->moderation_state->value == 'published')) {
     // This node is being archived, so we need to delete the alias (which

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -124,10 +124,10 @@ function origins_workflow_form_taxonomy_term_form_alter(&$form, FormStateInterfa
  * Provide extra validation for taxonomy term edit form.
  */
 function _origins_workflow_validate_term_path_alias(&$form, FormStateInterface $form_state) {
-  // If this node has its moderation state set to 'archived' then make sure
+  // If this term is unpublished then make sure
   // that 'generate automatic alias' is un-checked and that the 'URL alias'
   // field is empty. This will make sure that there is no alias and hence
-  // it will be possible to create a redirect to a replacement node if
+  // it will be possible to create a redirect to a replacement term if
   // necessary.
   if ($form_state->getValue('status')['value'] == 0) {
     $path_alias_settings = $form_state->getValue('path');

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -142,28 +142,19 @@ function _origins_workflow_validate_term_path_alias(&$form, FormStateInterface $
  */
 function origins_workflow_entity_update(EntityInterface $entity) {
   // Identify nodes being archived.
-  if ($entity->moderation_state->value == 'archived') {
-    if ($entity->original->moderation_state->value == 'published') {
-      // This node is being archived, so we need to delete the alias (which
-      // will enable us to create redirects if we want to).
-      $actual_alias = \Drupal::service('path.alias_manager')->getAliasByPath('/node/' . $entity->nid->value);
+  if (($entity->moderation_state->value == 'archived')
+    && ($entity->original->moderation_state->value == 'published')) {
+    // This node is being archived, so we need to delete the alias (which
+    // will enable us to create redirects if we want to).
+    if (!empty($entity->nid->value)) {
       // Get all aliases attached to this node.
       $path_alias_storage = \Drupal::entityTypeManager()->getStorage('path_alias');
       $alias_objects = $path_alias_storage->loadByProperties([
         'path' => '/node/' . $entity->nid->value,
         'langcode' => $entity->language()->getId()
       ]);
+      // Delete all aliases for this node.
       $path_alias_storage->delete($alias_objects);
-      $alias_manager = \Drupal::service('path_alias.manager');
-      $alias_manager->cacheClear('/node/' . $entity->nid->value);
-      /*foreach ($alias_objects as $alias_object) {
-        // We could delete all aliases here, but for now we'll just delete the main one.
-        if ($alias_object->alias->value == $actual_alias) {
-          // Delete the main alias.
-          $path_alias_storage->delete([$alias_object]);
-          //$alias_object->delete();
-        }
-      }*/
     }
   }
 }


### PR DESCRIPTION
Changes to make sure that aliases are deleted when nodes are archived or when taxonomy terms are unpublished.
By doing this, it becomes possible to create redirects from old nodes or terms to new ones.

Further functionality has now been added to ensure that this works when a node is archived via the moderation sidebar.

See also related PR https://github.com/dof-dss/nidirect-drupal/pull/668