### PR TITLE
D8 un 398

### DIFF
--- a/origins_workflow/config/optional/views.view.workflow_moderation.yml
+++ b/origins_workflow/config/optional/views.view.workflow_moderation.yml
@@ -1,4 +1,4 @@
-uuid: 16640f49-fd2a-494d-bd82-985cc5cfa482
+uuid: 69bd0e4e-76f9-4d88-80fb-d34050c023ca
 langcode: en
 status: true
 dependencies:
@@ -6,16 +6,14 @@ dependencies:
     - user.role.admin_user
     - user.role.administrator
     - user.role.author_user
-    - user.role.editor_user
     - user.role.supervisor_user
     - workflows.workflow.nics_editorial_workflow
   module:
     - content_moderation
-    - datetime
     - node
     - user
 _core:
-  default_config_hash: qmeJXDzqRz-sV5iAHcmJgIoorYcaDuZ4J8TrVdqQ8uk
+  default_config_hash: UNrEnYdcQfORxKj-iAgyuHKbNCTNhNhhI_UpLYkHd5o
 id: workflow_moderation
 label: 'Workflow: Moderation'
 module: views
@@ -37,7 +35,6 @@ display:
             administrator: administrator
             author_user: author_user
             supervisor_user: supervisor_user
-            editor_user: editor_user
             admin_user: admin_user
       cache:
         type: tag
@@ -958,6 +955,7 @@ display:
         filters: false
         filter_groups: false
         fields: false
+        access: false
       path: admin/content/all-drafts
       filters:
         moderation_state:
@@ -1911,6 +1909,10 @@ display:
           entity_type: node
           entity_field: changed
           plugin_id: field
+      access:
+        type: perm
+        options:
+          perm: 'view own unpublished content'
     cache_metadata:
       max-age: -1
       contexts:
@@ -1919,7 +1921,7 @@ display:
         - url
         - url.query_args
         - 'user.node_grants:view'
-        - user.roles
+        - user.permissions
       tags:
         - 'config:workflow_list'
   my_drafts:
@@ -1936,6 +1938,7 @@ display:
         filters: false
         filter_groups: false
         fields: false
+        access: false
       path: admin/content/drafts
       filters:
         moderation_state:
@@ -2874,6 +2877,10 @@ display:
           entity_type: node
           entity_field: changed
           plugin_id: field
+      access:
+        type: perm
+        options:
+          perm: 'view own unpublished content'
     cache_metadata:
       max-age: -1
       contexts:
@@ -2883,7 +2890,7 @@ display:
         - url.query_args
         - user
         - 'user.node_grants:view'
-        - user.roles
+        - user.permissions
       tags:
         - 'config:workflow_list'
   needs_audit:
@@ -3700,6 +3707,7 @@ display:
       defaults:
         filters: false
         filter_groups: false
+        access: false
       filters:
         moderation_state:
           id: moderation_state
@@ -3947,6 +3955,10 @@ display:
         operator: AND
         groups:
           1: AND
+      access:
+        type: perm
+        options:
+          perm: 'use nics_editorial_workflow transition publish'
     cache_metadata:
       max-age: -1
       contexts:
@@ -3955,6 +3967,6 @@ display:
         - url
         - url.query_args
         - 'user.node_grants:view'
-        - user.roles
+        - user.permissions
       tags:
         - 'config:workflow_list'

--- a/origins_workflow/config/optional/views.view.workflow_moderation.yml
+++ b/origins_workflow/config/optional/views.view.workflow_moderation.yml
@@ -1,4 +1,4 @@
-uuid: 69bd0e4e-76f9-4d88-80fb-d34050c023ca
+uuid: c6b3a04b-630f-45e6-9d5b-ba11759fb8eb
 langcode: en
 status: true
 dependencies:
@@ -1912,7 +1912,7 @@ display:
       access:
         type: perm
         options:
-          perm: 'view own unpublished content'
+          perm: 'view any unpublished content'
     cache_metadata:
       max-age: -1
       contexts:

--- a/origins_workflow/config/optional/views.view.workflow_moderation.yml
+++ b/origins_workflow/config/optional/views.view.workflow_moderation.yml
@@ -29,13 +29,9 @@ display:
     position: 0
     display_options:
       access:
-        type: role
+        type: perm
         options:
-          role:
-            administrator: administrator
-            author_user: author_user
-            supervisor_user: supervisor_user
-            admin_user: admin_user
+          perm: 'view any unpublished content'
       cache:
         type: tag
         options: {  }

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -147,19 +147,21 @@ function origins_workflow_entity_update(EntityInterface $entity) {
   // re-creates the alias, and the code in here deletes it !
   // We want the alias deletion to run last so that it really
   // is deleted.
-  if (($entity->moderation_state->value == 'archived')
-    && ($entity->original->moderation_state->value == 'published')) {
-    // This node is being archived, so we need to delete the alias (which
-    // will enable us to create redirects if we want to).
-    if (!empty($entity->nid->value)) {
-      // Get all aliases attached to this node.
-      $path_alias_storage = \Drupal::entityTypeManager()->getStorage('path_alias');
-      $alias_objects = $path_alias_storage->loadByProperties([
-        'path' => '/node/' . $entity->nid->value,
-        'langcode' => $entity->language()->getId()
-      ]);
-      // Delete all aliases for this node.
-      $path_alias_storage->delete($alias_objects);
+  if (isset($entity->moderation_state)) {
+    if (($entity->moderation_state->value == 'archived')
+      && ($entity->original->moderation_state->value == 'published')) {
+      // This node is being archived, so we need to delete the alias (which
+      // will enable us to create redirects if we want to).
+      if (!empty($entity->nid->value)) {
+        // Get all aliases attached to this node.
+        $path_alias_storage = \Drupal::entityTypeManager()->getStorage('path_alias');
+        $alias_objects = $path_alias_storage->loadByProperties([
+          'path' => '/node/' . $entity->nid->value,
+          'langcode' => $entity->language()->getId()
+        ]);
+        // Delete all aliases for this node.
+        $path_alias_storage->delete($alias_objects);
+      }
     }
   }
 }


### PR DESCRIPTION
- Remove 'editor' role dependency from Origins workflow moderation view as this role is not being used in Unity
- Fix bug in Origins module that was causing an error to be thrown when installing new sites 