### PR TITLE
Omit transitions that don't match the revision moderation state, not the node

### DIFF
--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -579,7 +579,17 @@ function origins_workflow_entity_operation(EntityInterface $entity) {
     // Quick publish isn't detected as an equivalent operation/status as published
     // so we prune it off here for now as it makes no sense ot quick publish an
     // already published piece of content.
-    if ($entity->moderation_state->value === 'published') {
+    $revision_id = \Drupal::entityTypeManager()
+      ->getStorage('node')
+      ->getLatestRevisionId($entity->id());
+    $revision_moderation_state = \Drupal::entityTypeManager()
+      ->getStorage('node')
+      ->loadRevision($revision_id)
+      ->moderation_state->value;
+
+    $node_moderation_state = $entity->moderation_state->value;
+
+    if ($revision_moderation_state === 'published') {
       unset($transitions['quick_publish']);
     }
 
@@ -598,7 +608,7 @@ function origins_workflow_entity_operation(EntityInterface $entity) {
         continue;
       }
 
-      if ($transition->to()->id() === $entity->moderation_state->value) {
+      if ($transition->to()->id() === $revision_moderation_state) {
         // Don't present link to change moderation state to the current value.
         continue;
       }


### PR DESCRIPTION
Related: https://github.com/dof-dss/nidirect-drupal/pull/687