### PR TITLE
D8NID-1198 webform descriptions not displaying

### DIFF
--- a/origins_form_descriptions/css/form_descriptions.css
+++ b/origins_form_descriptions/css/form_descriptions.css
@@ -1,6 +1,5 @@
 /* Higher specificity than in form.css */
 .form-item div.description {
-  display: block;
   margin: .5em 0 .75em;
   line-height: 1.5;
 }

--- a/origins_form_descriptions/js/form_descriptions.js
+++ b/origins_form_descriptions/js/form_descriptions.js
@@ -1,7 +1,7 @@
 (function ($, Drupal) {
   Drupal.behaviors.formDescriptions = {
     attach: function attach (context) {
-      $('.description').each(function(){
+      $('.form-item .description').each(function(){
         // Find parent field ID, derive from the description id attribute.
         const descId = $(this).attr('id');
         const suffix = '--description';

--- a/origins_form_descriptions/origins_form_descriptions.module
+++ b/origins_form_descriptions/origins_form_descriptions.module
@@ -29,18 +29,6 @@ function origins_form_descriptions_form_media_form_alter(&$form, FormStateInterf
 }
 
 /**
- * Implements hook_preprocess_form_element().
- */
-function origins_form_descriptions_preprocess_form_element(&$variables) {
-  if (empty($variables['description']['attributes'])) {
-    return;
-  }
-
-  // Add a default hidden class to avoid visual jerkiness when loading.
-  $variables['description']['attributes']->addClass('js-hide');
-}
-
-/**
  * Implements hook_theme_registry_alter
  */
 function origins_form_descriptions_theme_registry_alter(&$theme_registry) {


### PR DESCRIPTION
Remove the hook adding js-hide to all form element descriptions.  The class is not being removed on page load and causes descriptions to remain hidden.  For node and term edit forms the issue is not apparent because CSS in the module was overriding the js-hide class and hiding the problem.