### PR TITLE
D8NID-1257 TOC logic tweaks

### DIFF
--- a/origins_toc/js/origins_toc.js
+++ b/origins_toc/js/origins_toc.js
@@ -14,18 +14,20 @@
         return;
       }
 
-      var tocHeadings = $(toc_settings.toc_source_container + ' ' + toc_settings.toc_element, context).once('attachToC');
+      var tocHeadings = $(toc_settings.toc_source_container + ' > ' + toc_settings.toc_element, context).once('attachToC');
+      var viewport_height = $(window).height();
+      var source_container_height = $(toc_settings.toc_source_container).height();
+      var text_screen_count = source_container_height / viewport_height;
 
-      if (tocHeadings.length > 2) {
-
-        let tocHeadings = $(toc_settings.toc_source_container + ' ' + toc_settings.toc_element).not(toc_settings.toc_exclusions);
-        let $tocList = $('<ul class="nav-menu" />');
-        let $headingText = Drupal.t(toc_settings.toc_title);
-        let $skipTocText = Drupal.t('Skip table of contents');
+      if ((tocHeadings.length > 2 && text_screen_count > 2) || (tocHeadings.length > 3 && text_screen_count > 1)) {
+        var tocHeadings = $(toc_settings.toc_source_container + ' ' + toc_settings.toc_element).not(toc_settings.toc_exclusions);
+        var $tocList = $('<ul class="nav-menu" />');
+        var $headingText = Drupal.t(toc_settings.toc_title);
+        var $skipTocText = Drupal.t('Skip table of contents');
 
         // Iterate each element, append an anchor id and append link to block list.
         $(tocHeadings, context).once('toc').each(function(index) {
-          const $linkText = $(this).text();
+          var $linkText = $(this).text();
 
           // Ignore the 'more useful links' section, if present.
           if ($linkText.toLowerCase() == 'more useful links') {
@@ -44,9 +46,9 @@
           );
         });
 
+        var $tocMain = $(toc_settings.toc_location);
+        var $tocBlock = $('<nav class="sub-menu toc-menu" aria-labelledby="toc-menu-heading" />');
 
-        let $tocMain = $(toc_settings.toc_location);
-        let $tocBlock = $('<nav class="sub-menu toc-menu" aria-labelledby="toc-menu-heading" />');
         $tocBlock.prepend('<h2 id="toc-menu-heading" class="menu-title">' + $headingText + '</h2>',
           '<a href="#toc-main-skip" class="skip-link visually-hidden focusable" aria-label="' + $skipTocText + '">' +
           $skipTocText +
@@ -58,10 +60,12 @@
         } else {
           $tocMain.after($tocBlock, '<a id="toc-main-skip" tabindex="-1" class="visually-hidden" aria-hidden="true"></a>');
         }
-
-
       }
-
+      else {
+        console.log('TOC not shown - page too short');
+        console.log('TOC heading count: ' + tocHeadings.length);
+        console.log('TOC text screen count: ' + text_screen_count);
+      }
     }
   };
 })(jQuery, Drupal, drupalSettings);


### PR DESCRIPTION
Align TOC with D7 version so that it now displays when there are more than 2 headings AND the content container is of a certain height compared to viewport height.  Also change "let" and "const" to "var" for ie11 compatibility