### PR TITLE
Add default theme property to test class

### DIFF
--- a/origins_workflow/tests/src/Functional/AuditTest.php
+++ b/origins_workflow/tests/src/Functional/AuditTest.php
@@ -28,6 +28,13 @@ class AuditTest extends BrowserTestBase {
   protected $profile = 'test_profile';
 
   /**
+   * Drupal\Tests\BrowserTestBase::$defaultTheme is required. See
+   * https://www.drupal.org/node/3083055, which includes recommendations
+   * on which theme to use.
+   */
+  protected $defaultTheme = 'classy';
+
+  /**
    * The entity type manager.
    *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface

--- a/origins_workflow/tests/src/Functional/AuditTest.php
+++ b/origins_workflow/tests/src/Functional/AuditTest.php
@@ -31,6 +31,8 @@ class AuditTest extends BrowserTestBase {
    * Drupal\Tests\BrowserTestBase::$defaultTheme is required. See
    * https://www.drupal.org/node/3083055, which includes recommendations
    * on which theme to use.
+   *
+   * @var string
    */
   protected $defaultTheme = 'classy';
 


### PR DESCRIPTION
Needed now that 9.x and related packages around drupal-check begin to look for these properties.