### PR TITLE
D8 nid 1401 revisions overview

### DIFF
--- a/origins_workflow/css/admin.css
+++ b/origins_workflow/css/admin.css
@@ -9,3 +9,28 @@ body.path-admin form.views-exposed-form div.chosen-drop ul.chosen-results li.gro
 .origins-audit-actions .button {
   margin: .5em !important;
 }
+
+/* Drupal revisions overview page. */
+#edit-node-revisions-table th {
+  color: #000; /* better contrast with th background */
+}
+#edit-node-revisions-table .revision-draft {
+  background-color: #FFB3B3; /* pink */
+}
+#edit-node-revisions-table .revision-needs_review {
+  background-color: #ffeeaa; /* yellow */
+}
+#edit-node-revisions-table .revision-published {
+  background-color: #b6ffb6; /* light green */
+}
+#edit-node-revisions-table .revision-archived {
+  background-color: #dfdfdf; /* light grey */
+}
+#edit-node-revisions-table a:not(.dropbutton a) {
+  color: #00558A; /* darken link color for better contrast */
+  text-decoration: underline;
+}
+
+
+
+

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -392,28 +392,30 @@ function _audit_link($field, $dt, $nid) {
  * Implements hook_preprocess_table().
  */
 function origins_workflow_preprocess_table(&$variables) {
-  // Add new 'Revision Number' column to the node revisions tab.
-  //
-  // Making this change in preprocess is not beautiful, but seems
-  // to be the only workable solution as the 'diff' module has
-  // already been enabled and has taken over the core route with
-  // its own controller. If we created our own controller to do
-  // this then we would have to call the contrib controller,
-  // which does not sound like a good idea.
+
+  // Preprocess node revisions table.
   if (\Drupal::routeMatch()->getRouteName() == 'entity.node.version_history') {
-    // Add 'Revision Number' column header.
+
+    // Get the current node we are showing revisions for.
+    $node = \Drupal::routeMatch()->getParameter('node');
+
+    // Add new 'Revision Number' column to the node revisions tab.
+    //
+    // Making this change in preprocess is not beautiful, but seems
+    // to be the only workable solution as the 'diff' module has
+    // already been enabled and has taken over the core route with
+    // its own controller. If we created our own controller to do
+    // this then we would have to call the contrib controller,
+    // which does not sound like a good idea.
     $new_head = [
       'tag' => 'th',
       'content' => [
-        '#markup' => t('Revision number'),
+        '#markup' => t('Revision No.'),
       ],
     ];
 
-    // Insert this new column after the first one.
-    // Use array_splice as we don't know exactly how many columns there will be
-    // (and this code should work whether the 'diff' module has been enabled or
-    // not).
-    array_splice($variables['header'], 1, 0, [$new_head]);
+    // Insert revision number column at the beginning.
+    array_unshift($variables['header'], $new_head);
     if (isset($variables['header']['select_column_one'])) {
       $variables['header']['select_column_one']['content'] = ['#markup' => t('Compare revision 1')];
     }
@@ -426,27 +428,33 @@ function origins_workflow_preprocess_table(&$variables) {
     if (\Drupal::moduleHandler()->moduleExists('diff')) {
       $action_column = 3;
     }
-    // Loop through the rows and add the revision number column to each.
+    // Loop through the rows and:
+    // - add the revision number column to each.
+    // - add 'Create Draft of Published' link to published revision.
     foreach ($variables['rows'] as $idx => $row) {
-      $this_version = '';
+      // Work out the revision for this row.
+      $this_revisionId = '';
       if (isset($row['cells'][$action_column]['content']['#links'])) {
-        // Cheekily extract current revision from the 'revert' button link.
+        // Cheekily extract this row's revision from the 'revert' button link.
         $this_url = $row['cells'][$action_column]['content']['#links']['revert']['url'];
         if (isset($this_url)) {
-          $this_version = $this_url->getRouteParameters()['node_revision'];
+          $this_revisionId = $this_url->getRouteParameters()['node_revision'];
         }
       }
       else {
         // There is no 'revert' button in this row, therefore it must be the
-        // current versionand we need to add a 'Create Draft of Published' link.
-        $this_version = _create_draft_link_for_revision($variables, $idx, $row);
+        // default revision.
+        $this_revisionId = $node->getRevisionId();
+        // Add class to the row for the default revision
+        // to indicate it's moderation state.
+        $row['attributes']->addClass('revision-' . $node->get('moderation_state')->getValue()[0]['value']);
+
+        // Create a "Create Draft of Published" link.
+        _create_draft_link_for_revision($variables, $node, $idx, $row);
       }
-      $new_col = ['tag' => 'td', 'content' => ['#markup' => $this_version]];
-      // Insert this new column after the first one.
-      // Use array_splice as we don't know exactly how many columns there
-      // will be (and this code should work whether the 'diff' module has
-      // been enabled or not).
-      array_splice($variables['rows'][$idx]['cells'], 1, 0, [$new_col]);
+      $new_col = ['tag' => 'td', 'content' => ['#markup' => $this_revisionId]];
+      // Insert revision number column at the beginning.
+      array_unshift($variables['rows'][$idx]['cells'], $new_col);
     }
   }
 }
@@ -454,11 +462,7 @@ function origins_workflow_preprocess_table(&$variables) {
 /**
  * Add a 'Create Draft of Published' link.
  */
-function _create_draft_link_for_revision(&$variables, $idx, $row) {
-  // Cannot manage to extract the revision id from this row
-  // anywhere so we'll (reluctantly) have to load up the full node.
-  $node = \Drupal::routeMatch()->getParameter('node');
-  $this_version = $node->getRevisionId();
+function _create_draft_link_for_revision(&$variables, $node, $idx, $row) {
   // Does this user have permission to create drafts of published ?
   if (\Drupal::currentUser()->hasPermission('use nics_editorial_workflow transition draft_of_published')) {
     // Now change the 'Current Revision' markup to a
@@ -491,7 +495,6 @@ function _create_draft_link_for_revision(&$variables, $idx, $row) {
       }
     }
   }
-  return $this_version;
 }
 
 /**


### PR DESCRIPTION
This started off with me making some experimental changes to code Martin originally wrote.

The original code preprocesses the revisions table shown on the revisions tab for a node.  It added a revision number column and a "Create draft of published" button in the operations column for the default published revision.

I've modified the code so that:
- The revision number column comes first
- A class is added to the default revision row to indicate the moderation state.  Previous the row for the default revision was always coloured yellow.  Now it will be yellow for draft, pink for needs review, green for published and grey for archived.

<img width="1454" alt="Screenshot 2021-09-22 at 17 13 35" src="https://user-images.githubusercontent.com/52457988/134382297-c5ea5d76-7858-4a3b-a145-6e52f6926b19.png">
<img width="1452" alt="Screenshot 2021-09-22 at 17 14 16" src="https://user
<img width="1451" alt="Screenshot 2021-09-22 at 17 16 17" src="https://user-images.githubusercontent.com/52457988/134382371-5f850daa-3cc9-479f-ba34-a04cd3edbfbb.png">
-images.githubusercontent.com/52457988/134382326-b46cc81b-3eba-4ea3-820d-2b54f8f2484b.png">
<img width="1452" alt="Screenshot 2021-09-22 at 17 15 26" src="https://user-images.githubusercontent.com/52457988/134382346-240079bc-b424-4d0f-acda-5fea72a985b9.png">

