### PR TITLE
Changing ajax callback event to submit

### DIFF
--- a/origins_unique_title/origins_unique_title.module
+++ b/origins_unique_title/origins_unique_title.module
@@ -12,13 +12,8 @@ use Drupal\Core\Form\FormStateInterface;
 function origins_unique_title_form_node_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   $form['title']['widget'][0]['value']['#ajax'] = [
     'callback' => 'origins_unique_title_check_title',
-    'disable-refocus' => TRUE,
-    'event' => 'change',
+    'event' => 'submit',
     'wrapper' => 'title-unique',
-    'progress' => [
-      'type' => 'throbber',
-      'message' => t('Checking if title is unique') . '...',
-    ],
   ];
 
   $form['title_unique'] = [


### PR DESCRIPTION
If a user adds a new title and then tries to save the node as a draft while keeping the focus on the title field then the new title is not saved or therefore checked against other titles using the change event.
Using submit will run the check on a form submit and therefore save drafts with title changes also checking if the title is unique.