### PR TITLE
TOC should not display links to visually-hidden headings

### DIFF
--- a/origins_toc/js/origins_toc.js
+++ b/origins_toc/js/origins_toc.js
@@ -39,6 +39,11 @@
         $(tocHeadings, context).once('toc').each(function(index) {
           var $linkText = $(this).text();
 
+          // Ignore visually hidden elements.
+          if ($(this).hasClass('visually-hidden')) {
+            return;
+          }
+
           // Ignore the 'more useful links' section, if present.
           if ($linkText.toLowerCase() == 'more useful links') {
             return;


### PR DESCRIPTION
Quick simple fix to stop the table of contents menu showing links to headings that are visually hidden - for example the visually heading heading for book navigation as shown on https://www.nidirect.gov.uk/articles/introduction-highway-code

<img width="762" alt="Screenshot 2021-09-30 at 16 54 00" src="https://user-images.githubusercontent.com/52457988/135491701-2dcd0700-e0c5-4e1a-9ec4-bdc2a473fc75.png">
