### PR TITLE
Adjustments to Shamrock banner based on NIDirect rendering

### DIFF
--- a/origins_shamrock/css/shamrock_banner.css
+++ b/origins_shamrock/css/shamrock_banner.css
@@ -1,11 +1,12 @@
 .opsh--banner {
   background: #000;
-  padding: 1.5em 21px;
+  padding: 0.5em 21px;
+  color: #fff;
 }
 
 @media screen and (max-width: 979px) {
   .opsh--banner {
-    padding: 1.5em 12px;
+    padding: 0.5em 12px;
   }
 }
 
@@ -46,49 +47,55 @@
 .opsh__title {
   display: block;
   font-size: 3.6rem;
-  margin-bottom: .5em;
   font-weight: bold;
   line-height: 1.25;
+  padding: 0.25em 21px;
 }
 
 .opsh__msg {
   display: block;
-  font-size: 1.8rem;
+  font-size: 1.6rem;
   line-height: 2.7rem;
-  margin: .6rem 0 0;
+  margin: 0;
 }
 
 .opsh__read-more {
   display: inline-block;
-  font-size: 1.6rem;
+  font-size: 1.4rem;
   line-height: 2.1rem;
-  margin: .6rem 0;
   text-decoration: underline;
 }
 
 @media screen and (max-width: 599px) {
   .opsh__title {
     font-size: 2.8rem;
-    margin-bottom: 1.6rem;
     line-height: 3.2rem;
   }
 
-  .opsh__msg {
+  .opsh__title.opsh__msg {
     font-size: 1.6rem;
     line-height: 2.4rem;
+    margin: 0;
   }
 
-  .opsh__read-more {
+  .opsh__msg.opsh__read-more {
     font-size: 1.4rem;
     line-height: 2.1rem;
-    margin: .3rem 0;
   }
 }
 
 @media screen and (max-width: 480px) {
   .opsh__title {
-    font-size: 2.1rem;
-    margin-bottom: 1.6rem;
+    font-size: 2.6rem;
+    margin: 0;
     line-height: 2.4rem;
+  }
+
+  .opsh__title.opsh__msg {
+    font-size: 1.6rem;
+  }
+
+  .opsh__title.opsh__msg .opsh__read-more {
+    font-size: 1.4rem;
   }
 }


### PR DESCRIPTION
This PR aims to tighten up the styling which had too much spacing and inaccurate colours:

# Before

![image](https://user-images.githubusercontent.com/451261/139279347-3ccc379f-cf99-468d-a10c-1d154ac78ccf.png)

# After

## Desktop (over 700px wide)

![image](https://user-images.githubusercontent.com/451261/139277959-3882d11d-1322-4ac4-8a39-d8e9c5705a1a.png)

## Tablet (around 700px wide)

![image](https://user-images.githubusercontent.com/451261/139278301-d63c9b18-2ccb-460f-907f-0051c05746be.png)

## Mobile (<= 480px wide)

![image](https://user-images.githubusercontent.com/451261/139279078-cbb3414b-091f-4bb2-b561-7fcb25575086.png)

