### PR TITLE
Resolves error caused when opening moderation sidebar on a theme taxo…

### DIFF
--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -599,6 +599,12 @@ function _create_draft_link_for_revision(&$variables, $node, $idx, $row) {
  * Implements hook_moderation_sidebar_alter().
  */
 function origins_workflow_moderation_sidebar_alter(array &$build, EntityInterface $entity) {
+
+  // Early return if this entity has no moderation state.
+  if (empty($entity->moderation_state)) {
+    return;
+  }
+
   // Get current moderation state.
   $current_state = $entity->moderation_state->value;
 


### PR DESCRIPTION
…nomy page:

 "Notice: Trying to get property 'value' of non-object in origins_workflow_moderation_sidebar_alter() (line 603 of /app/web/modules/origins/origins_workflow/origins_workflow.module)"