### PR TITLE
D8NID-1465

### DIFF
--- a/origins_media/css/file-managed.css
+++ b/origins_media/css/file-managed.css
@@ -1,0 +1,3 @@
+.form-managed-file [data-drupal-selector*="-remove-button"] {
+  display: none;
+}

--- a/origins_media/origins_media.libraries.yml
+++ b/origins_media/origins_media.libraries.yml
@@ -4,3 +4,10 @@ entity_browser_entity_reference:
       css/entity-browser-entity-reference.css: {}
   dependencies:
     - entity_browser/entity_list
+
+managed_file:
+  css:
+    theme:
+      css/file-managed.css: {}
+  dependencies:
+    - core/drupal

--- a/origins_media/origins_media.module
+++ b/origins_media/origins_media.module
@@ -117,6 +117,7 @@ function origins_media_form_alter(&$form, FormStateInterface $form_state, $form_
 
   // Alterations for specific media entity forms.
   switch ($form_id) {
+
     case 'media_document_edit_form':
     case 'media_image_edit_form':
     case 'media_video_edit_form':
@@ -124,6 +125,7 @@ function origins_media_form_alter(&$form, FormStateInterface $form_state, $form_
       // Attach library to managed file fields when editing media entities.
       $form['#attached']['library'][] = 'origins_media/managed_file';
       break;
+
     case 'media_document_delete_form':
     case 'media_image_delete_form':
     case 'media_video_delete_form':
@@ -135,6 +137,7 @@ function origins_media_form_alter(&$form, FormStateInterface $form_state, $form_
         $form['also_delete_file']['#default_value'] = 1;
       }
       break;
+      
   }
 }
 

--- a/origins_media/origins_media.module
+++ b/origins_media/origins_media.module
@@ -70,18 +70,6 @@ function origins_media_form_entity_embed_dialog_alter(&$form, FormStateInterface
 }
 
 /**
- * Implements hook_form_FORM_ID_alter().
- */
-function origins_media_form_media_document_delete_form_alter(&$form, FormStateInterface &$form_state) {
-  // When media items are deleted, we want the media_file_delete module to
-  // delete the associated file from the file system. Ensure the option
-  // "Also delete the associated file?" is checked by default.
-  if (!empty($form['also_delete_file'])) {
-    $form['also_delete_file']['#default_value'] = 1;
-  }
-}
-
-/**
  * Implements hook_entity_embed_alter().
  *
  * Swap between entity embed view modes for Maps when you're viewing or editing nodes.
@@ -125,6 +113,28 @@ function origins_media_form_alter(&$form, FormStateInterface $form_state, $form_
   // Disable Chosen select for embedded images view mode.
   if ($form_id === 'editor_media_dialog') {
     $form['view_mode']['#chosen'] = FALSE;
+  }
+
+  // Alterations for specific media entity forms.
+  switch ($form_id) {
+    case 'media_document_edit_form':
+    case 'media_image_edit_form':
+    case 'media_video_edit_form':
+    case 'media_audio_edit_form':
+      // Attach library to managed file fields when editing media entities.
+      $form['#attached']['library'][] = 'origins_media/managed_file';
+      break;
+    case 'media_document_delete_form':
+    case 'media_image_delete_form':
+    case 'media_video_delete_form':
+    case 'media_audio_delete_form':
+      // When media items are deleted, we want the media_file_delete module to
+      // delete the associated file from the file system. Ensure the option
+      // "Also delete the associated file?" is checked by default.
+      if (!empty($form['also_delete_file'])) {
+        $form['also_delete_file']['#default_value'] = 1;
+      }
+      break;
   }
 }
 

--- a/origins_media/origins_media.module
+++ b/origins_media/origins_media.module
@@ -117,7 +117,6 @@ function origins_media_form_alter(&$form, FormStateInterface $form_state, $form_
 
   // Alterations for specific media entity forms.
   switch ($form_id) {
-
     case 'media_document_edit_form':
     case 'media_image_edit_form':
     case 'media_video_edit_form':
@@ -137,7 +136,6 @@ function origins_media_form_alter(&$form, FormStateInterface $form_state, $form_
         $form['also_delete_file']['#default_value'] = 1;
       }
       break;
-      
   }
 }
 


### PR DESCRIPTION
Media entity edit and delete form changes:
- When deleting media entities, ensure option "Also delete associated file" is checked by default for documents, video, images and audio
- When editing media entities, attach a library that hides file remove button using CSS

I went round the houses trying to find a way to cleanly hook into the field_media_file field on media entity edit forms and hide the remove button - but really struggled with that.  

It is a widget with ajax doing stuff with the button (changing it to an upload button when you remove the file).  There are process callback functions and pre_render callback functions involved (see https://api.drupal.org/api/drupal/core%21modules%21file%21src%21Element%21ManagedFile.php/class/ManagedFile/9.0.x) and I could not work out how to override these or inject a custom callback ... And I couldn't find any decent documentation for Drupal 8/9 on the matter (seems much easier in Drupal 7 - https://drupal.stackexchange.com/questions/32358/removing-the-upload-button-in-managed-files).  So instead I've gone with a quick and dirty CSS solution!
