### PR TITLE
Non-css solution to hide the file remove button when editing media entities

### DIFF
--- a/origins_media/css/file-managed.css
+++ b/origins_media/css/file-managed.css
@@ -1,3 +1,0 @@
-.form-managed-file [data-drupal-selector*="-remove-button"] {
-  display: none;
-}

--- a/origins_media/origins_media.libraries.yml
+++ b/origins_media/origins_media.libraries.yml
@@ -4,10 +4,3 @@ entity_browser_entity_reference:
       css/entity-browser-entity-reference.css: {}
   dependencies:
     - entity_browser/entity_list
-
-managed_file:
-  css:
-    theme:
-      css/file-managed.css: {}
-  dependencies:
-    - core/drupal

--- a/origins_media/origins_media.module
+++ b/origins_media/origins_media.module
@@ -11,6 +11,7 @@ use Drupal\Core\Link;
 use Drupal\file\Entity\File;
 use Drupal\file\FileInterface;
 use Drupal\media\MediaInterface;
+use Drupal\origins_media\Element\ManagedFileTrustedCallback;
 use Drupal\views\Render\ViewsRenderPipelineMarkup;
 use Drupal\views\ViewExecutable;
 use Drupal\origins_media\GeoLocationFormElementRenderer;
@@ -121,8 +122,11 @@ function origins_media_form_alter(&$form, FormStateInterface $form_state, $form_
     case 'media_image_edit_form':
     case 'media_video_edit_form':
     case 'media_audio_edit_form':
-      // Attach library to managed file fields when editing media entities.
-      $form['#attached']['library'][] = 'origins_media/managed_file';
+      // Add a process callback to (managed_file) file field.
+      $form['field_media_file']['widget'][0]['#process'][] = [
+        ManagedFileTrustedCallback::class,
+        'processManagedFile'
+      ];
       break;
 
     case 'media_document_delete_form':

--- a/origins_media/src/Element/ManagedFileTrustedCallback.php
+++ b/origins_media/src/Element/ManagedFileTrustedCallback.php
@@ -24,7 +24,7 @@ class ManagedFileTrustedCallback implements TrustedCallbackInterface {
    */
   public static function processManagedFile(&$element) {
     if (!empty($element['remove_button'])) {
-      $element['remove_button']['#access'] = false;
+      $element['remove_button']['#access'] = FALSE;
     }
     return $element;
   }

--- a/origins_media/src/Element/ManagedFileTrustedCallback.php
+++ b/origins_media/src/Element/ManagedFileTrustedCallback.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\origins_media\Element;
+
+use Drupal\Core\Security\TrustedCallbackInterface;
+
+/**
+ * Provides trusted callbacks for the Managed File form element in Media
+ * entity editing forms.
+ *
+ * @see origins_media_form_alter()
+ */
+class ManagedFileTrustedCallback implements TrustedCallbackInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function trustedCallbacks() {
+    return ['processManagedFile'];
+  }
+
+  /**
+   * Process callback for core's ManagedFile form element.
+   */
+  public static function processManagedFile(&$element) {
+    if (!empty($element['remove_button'])) {
+      $element['remove_button']['#access'] = false;
+    }
+    return $element;
+  }
+
+}


### PR DESCRIPTION
This https://www.drupal.org/node/2966725 helped me come up with a (hopefully better) solution for hiding the remove button on the file field when editing media entities ... No need to hide via CSS anymore.