### PR TITLE
Circleci fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,12 +14,13 @@ jobs:
           name: Fetch phpcs and dependencies
           command: |
             composer require drupal/coder --prefer-stable --no-interaction --optimize-autoloader
+            composer require slevomat/coding-standard --prefer-stable --no-interaction --optimize-autoloader
             # Move vendor directory up a level as we don't want to code-check all of that.
             mv vendor ../
       - run:
           name: Fetch phpcs convenience script
           command: |
-            curl https://raw.githubusercontent.com/dof-dss/nidirect-drupal/main/phpcs.sh -o /home/circleci/project/phpcs.sh
+            curl https://raw.githubusercontent.com/dof-dss/nidirect-drupal/development/phpcs.sh -o /home/circleci/project/phpcs.sh
             chmod +x /home/circleci/project/phpcs.sh
       - run:
           name: PHPCS analysis


### PR DESCRIPTION
- add phpcs dependency to prevent "ERROR: Referenced sniff "SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator" does not exist" (see https://www.drupal.org/project/coder/issues/3010032#comment-14391143)
- fetch phpcs.sh script from nidirect-drupal development branch instead of the main branch