### PR TITLE
Release 1.1.4

### DIFF
--- a/origins_common/css/origins-common-adminimal.css
+++ b/origins_common/css/origins-common-adminimal.css
@@ -9,3 +9,6 @@
 .form--inline .form-actions {
   flex: 100% 0 0;
 }
+.cke_combopanel.cke_combopanel__styles {
+  width: auto;
+}

--- a/origins_workflow/src/Form/AuditSettingsForm.php
+++ b/origins_workflow/src/Form/AuditSettingsForm.php
@@ -174,6 +174,7 @@ class AuditSettingsForm extends ConfigFormBase {
     if (!empty($field)) {
       // See if there is any data in this field.
       $ids = $this->entityTypeManager->getStorage('node')->getQuery()
+        ->accessCheck(TRUE)
         ->condition('type', $type)
         ->exists('field_next_audit_due')
         ->execute();


### PR DESCRIPTION
Needed to include the extra entity access parameter in the audit form settings form class, which satisfies deprecation errors and unblocks deployments.