### PR TITLE
Set headers in the JSON response for CORS

### DIFF
--- a/origins_shamrock/modules/origins_shamrock_admin/src/Controller/ShamrockDataController.php
+++ b/origins_shamrock/modules/origins_shamrock_admin/src/Controller/ShamrockDataController.php
@@ -46,9 +46,15 @@ class ShamrockDataController extends ControllerBase {
     $config = $this->config(ShamrockAdminForm::SETTINGS);
 
     $response = new JsonResponse();
-    $response->headers->set('Access-Control-Allow-Headers', ['x-csrf-token','content-type','accept','origin','x-requested-with']);
-    $response->headers->set('Access-Control-Allow-Origin', ['*']);
+    $response->headers->set('Access-Control-Allow-Headers', [
+      'x-csrf-token',
+      'content-type',
+      'accept',
+      'origin',
+      'x-requested-with'
+    ]);
     $response->headers->set('Access-Control-Allow-Methods', ['GET']);
+    $response->headers->set('Access-Control-Allow-Origin', ['*']);
 
     // If the Shamrock config has data build the banner, otherwise return
     // that it is not enabled.

--- a/origins_shamrock/modules/origins_shamrock_admin/src/Controller/ShamrockDataController.php
+++ b/origins_shamrock/modules/origins_shamrock_admin/src/Controller/ShamrockDataController.php
@@ -44,7 +44,11 @@ class ShamrockDataController extends ControllerBase {
    */
   public function index() {
     $config = $this->config(ShamrockAdminForm::SETTINGS);
+
     $response = new JsonResponse();
+    $response->headers->set('Access-Control-Allow-Headers', ['x-csrf-token','content-type','accept','origin','x-requested-with']);
+    $response->headers->set('Access-Control-Allow-Origin', ['*']);
+    $response->headers->set('Access-Control-Allow-Methods', ['GET']);
 
     // If the Shamrock config has data build the banner, otherwise return
     // that it is not enabled.


### PR DESCRIPTION
Instead of allowing all origins in cors.config in the services.yml, set CORS headers in the OPSH JSON response specifically.