### PR TITLE
Introduce facet view hint into block layout table rows.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           name: Download dependent contrib modules.
           command: |
             cd $PROJECT_ROOT
-            composer require drupal/entity_embed mglaman/drupal-check drupal/flag drupal/geolocation
+            composer require drupal/entity_embed mglaman/drupal-check drupal/flag drupal/geolocation drupal/facets
       - run:
           name: Move custom code into position
           command: mv ~/nicsdru_origins_modules $PROJECT_ROOT/web/modules/origins

--- a/origins_common/origins_common.info.yml
+++ b/origins_common/origins_common.info.yml
@@ -6,3 +6,4 @@ package: 'NICS: Origins'
 dependencies:
   - drupal:help
   - drupal:block
+  - drupal:facets

--- a/origins_common/origins_common.module
+++ b/origins_common/origins_common.module
@@ -5,10 +5,12 @@
  * Contains origins_common.module.
  */
 
+use Drupal\block\Entity\Block;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
+use Drupal\facets\FacetInterface;
 use Drupal\node\Entity\Node;
 
 /**
@@ -112,5 +114,43 @@ function origins_common_preprocess_page(&$variables) {
   if ($theme->getName() === 'adminimal_theme') {
     $variables['#attached']['library'][] = 'origins_common/adminimal';
   }
+}
 
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function origins_common_form_block_admin_display_form_alter(&$form) {
+  foreach ($form['blocks'] as $block_id => $block_info) {
+    if (preg_match('/^#/', $block_id)) {
+      // It's a render attribute so skip it.
+      continue;
+    }
+
+    $type = $block_info['type']['#markup'] ?? '';
+
+    if (preg_match('/facets/i', $type)) {
+      /** @var \Drupal\block\BlockInterface $block */
+      $block = Block::load($block_id);
+      $settings = $block->get('settings');
+
+      if (empty($settings)) {
+        return;
+      }
+
+      $facet_id = str_replace('facet_block:', '', $settings['id']);
+      /** @var \Drupal\facets\Entity\Facet $facet */
+      $facet = \Drupal::entityTypeManager()->getStorage('facets_facet')->load($facet_id);
+
+      if ($facet instanceof FacetInterface) {
+        /** @var \Drupal\facets\Plugin\facets\facet_source\SearchApiDisplay $source */
+        $source = $facet->getFacetSource();
+
+        $view_title = $source->getViewsDisplay()->getTitle();
+        // It's a facet block so we can adjust the title string.
+        $existing_text = $form['blocks'][$block_id]['info']['#plain_text'];
+        $form['blocks'][$block_id]['info']['#markup'] = "<em>(Facet view: ${view_title})</em> ${existing_text}";
+        unset($form['blocks'][$block_id]['info']['#plain_text']);
+      }
+    }
+  }
 }


### PR DESCRIPTION
Makes it easier to see which facet block relates to which view, especially when using multiple facet blocks across indices with the same title.

Looks like this:

![image](https://user-images.githubusercontent.com/451261/220675127-f07dfce6-d587-4dbc-be3d-7cf9d997beda.png)
