### PR TITLE
DEPT-244 ~ Fix misalignment of descriptions on node edit forms

### DIFF
--- a/origins_form_descriptions/js/form_descriptions.js
+++ b/origins_form_descriptions/js/form_descriptions.js
@@ -12,7 +12,18 @@
         // we do at least have a common prefix. Filter selects are fiddly,
         // because they share almost the exact same label attribute values
         // but we can use jQuery to only use the first label to avoid duplicates.
-        $('label[for^="' + labelFor + '"]').first().after($(this));
+        // if (!$(this).parents().is('fieldset')) {
+        if (!$(this).parent().is('.fieldset-wrapper') && !$(this).is('#edit-field-featured-content--description'))
+        // if (!$(this).is('#edit-field-consultation-dates-0--description')
+        //   && !$(this).is('#edit-field-featured-content--description')
+        //   && !$(this).is('#edit-field-last-updated-0--description'))
+        {
+          $('label[for^="' + labelFor + '"]').first().after($(this));
+        } else if ($(this).is('#edit-field-featured-content--description')) {
+          const desc = $(this).html();
+          $(this).prev().children('tbody').children('tr').first().before("<tr><td colspan='2'>" + desc + "</td></tr>");
+          $(this).remove();
+        }
       });
     }
   };

--- a/origins_form_descriptions/js/form_descriptions.js
+++ b/origins_form_descriptions/js/form_descriptions.js
@@ -12,12 +12,7 @@
         // we do at least have a common prefix. Filter selects are fiddly,
         // because they share almost the exact same label attribute values
         // but we can use jQuery to only use the first label to avoid duplicates.
-        // if (!$(this).parents().is('fieldset')) {
-        if (!$(this).parent().is('.fieldset-wrapper') && !$(this).is('#edit-field-featured-content--description'))
-        // if (!$(this).is('#edit-field-consultation-dates-0--description')
-        //   && !$(this).is('#edit-field-featured-content--description')
-        //   && !$(this).is('#edit-field-last-updated-0--description'))
-        {
+        if (!$(this).parent().is('.fieldset-wrapper') && !$(this).is('#edit-field-featured-content--description')) {
           $('label[for^="' + labelFor + '"]').first().after($(this));
         } else if ($(this).is('#edit-field-featured-content--description')) {
           const desc = $(this).html();

--- a/origins_form_descriptions/origins_form_descriptions.module
+++ b/origins_form_descriptions/origins_form_descriptions.module
@@ -38,14 +38,6 @@ function origins_form_descriptions_theme_registry_alter(&$theme_registry) {
   }
 }
 
-///**
-// * Implements hook_preprocess_form_element().
-// */
-//function origins_form_descriptions_preprocess_form_element(&$variables) {
-//  $variables['description_display'] = 'before';
-//  $variables['description']['attributes']['class'] = 'description';
-//}
-
 /**
  * Implements hook_preprocess_fieldset().
  */

--- a/origins_form_descriptions/origins_form_descriptions.module
+++ b/origins_form_descriptions/origins_form_descriptions.module
@@ -34,5 +34,23 @@ function origins_form_descriptions_form_media_form_alter(&$form, FormStateInterf
 function origins_form_descriptions_theme_registry_alter(&$theme_registry) {
   if (\Drupal::service('router.admin_context')->isAdminRoute()) {
     $theme_registry['fieldset__media_library_widget']['path'] = \Drupal::service('extension.list.module')->getPath('origins_form_descriptions') . '/templates/media-library';
+    $theme_registry['datetime_wrapper']['path'] = \Drupal::service('extension.list.module')->getPath('origins_form_descriptions') . '/templates/form';
   }
+}
+
+///**
+// * Implements hook_preprocess_form_element().
+// */
+//function origins_form_descriptions_preprocess_form_element(&$variables) {
+//  $variables['description_display'] = 'before';
+//  $variables['description']['attributes']['class'] = 'description';
+//}
+
+/**
+ * Implements hook_preprocess_fieldset().
+ */
+function origins_form_descriptions_preprocess_fieldset(&$variables) {
+  $variables['description_display'] = 'before';
+  $desc = $variables['description_display'];
+  $variables['description']['attributes']['class'] = $desc;
 }

--- a/origins_form_descriptions/templates/form/datetime-wrapper.html.twig
+++ b/origins_form_descriptions/templates/form/datetime-wrapper.html.twig
@@ -1,0 +1,36 @@
+{#
+/**
+ * @file
+ * Theme override of a datetime form wrapper.
+ *
+ * Available variables:
+ * - content: The form element to be output, usually a datelist, or datetime.
+ * - title: The title of the form element.
+ * - title_attributes: HTML attributes for the title wrapper.
+ * - description: Description text for the form element.
+ * - required: An indicator for whether the associated form element is required.
+ *
+ * @see template_preprocess_datetime_wrapper()
+ */
+#}
+{%
+  set title_classes = [
+    'label',
+    required ? 'js-form-required',
+    required ? 'form-required',
+  ]
+%}
+{% if title %}
+  <h4{{ title_attributes.addClass(title_classes) }}>{{ title }}</h4>
+{% endif %}
+{% if description %}
+  <div{{ description_attributes.addClass('description') }}>
+    {{ description }}
+  </div>
+{% endif %}
+{{ content }}
+{% if errors %}
+  <div class="form-item--error-message">
+    <strong>{{ errors }}</strong>
+  </div>
+{% endif %}


### PR DESCRIPTION
I have tested on nidirect and the only changes are positive ones (e.g. description is now above date fields)
