### PR TITLE
Update origins-translations.js to fix menu opening bug

### DIFF
--- a/origins_translations/js/origins-translations.js
+++ b/origins_translations/js/origins-translations.js
@@ -63,7 +63,7 @@
 
     // If focus leaves the translation menu, it should close.
     $(elm).focusout(function () {
-      if ($(this).is(':focus-within') !== true) {
+      if ($(this).is(':focus-within') !== true && $button.attr('aria-expanded') === 'true') {
         // Close it via the button.
         $button.click();
         // Ensure menu links cannot receive keyboard focus.


### PR DESCRIPTION
Fix issue where menu focusout event does not check if menu is open before attempting to close it and therefore ends up opening instead of closing it.