### PR TITLE
Add JS to origins_common to handle EUCC preferences

### DIFF
--- a/origins_common/js/gtag-eucc-consent.js
+++ b/origins_common/js/gtag-eucc-consent.js
@@ -17,21 +17,12 @@
     (Drupal.eu_cookie_compliance.queue = Drupal.eu_cookie_compliance.queue || []).push(arguments)
   };
 
-  // Handler for EUCC status / preference change events. Push an
-  // event to GTM container to indicate when EUCC preferences have been
-  // loaded or changed.
+  // Handler for EUCC status / preference change events.
   const euccConsentHandler = function(response) {
-
     window.cookieResponse = response;
-    const status = response.currentStatus ? parseInt(response.currentStatus) : null;
-
-    // Push event to indicate cookie choices made.
-    if (status) {
-      window.dataLayer.push({
-        'event': 'eucc_preferences_completed'
-      });
-      console.log('dataLayer push eucc_preferences_completed');
-    }
+    window.dataLayer.push({
+      'event': 'eucc_preferences_completed'
+    });
   }
 
   // Add handler to relevant EUCC events.

--- a/origins_common/js/gtag-eucc-consent.js
+++ b/origins_common/js/gtag-eucc-consent.js
@@ -1,0 +1,41 @@
+/**
+ * @file
+ * gtag-eucc-consent.js
+ *
+ * EUCC consent handling for Google Consent Mode.
+ */
+
+(function (Drupal, drupalSettings) {
+
+  // Initialise the dataLayer Google Tag Manager and gtag.js uses to
+  // pass information to tags.
+  window.dataLayer = window.dataLayer || [];
+
+  // Initialise Drupal.eu_cookie_compliance to add event
+  // handlers to it (see eu_cookie_compliance/README.md).
+  Drupal.eu_cookie_compliance = Drupal.eu_cookie_compliance || function() {
+    (Drupal.eu_cookie_compliance.queue = Drupal.eu_cookie_compliance.queue || []).push(arguments)
+  };
+
+  // Handler for EUCC status / preference change events. Push an
+  // event to GTM container to indicate when EUCC preferences have been
+  // loaded or changed.
+  const euccConsentHandler = function(response) {
+
+    window.cookieResponse = response;
+    const status = response.currentStatus ? parseInt(response.currentStatus) : null;
+
+    // Push event to indicate cookie choices made.
+    if (status) {
+      window.dataLayer.push({
+        'event': 'eucc_preferences_completed'
+      });
+      console.log('dataLayer push eucc_preferences_completed');
+    }
+  }
+
+  // Add handler to relevant EUCC events.
+  Drupal.eu_cookie_compliance('postPreferencesLoad', euccConsentHandler);
+  Drupal.eu_cookie_compliance('postStatusSave', euccConsentHandler);
+
+})(Drupal, drupalSettings);

--- a/origins_common/origins_common.info.yml
+++ b/origins_common/origins_common.info.yml
@@ -7,3 +7,5 @@ dependencies:
   - drupal:help
   - drupal:block
   - drupal:facets
+  - eu_cookie_compliance
+  - google_tag

--- a/origins_common/origins_common.info.yml
+++ b/origins_common/origins_common.info.yml
@@ -7,5 +7,3 @@ dependencies:
   - drupal:help
   - drupal:block
   - drupal:facets
-  - eu_cookie_compliance
-  - google_tag

--- a/origins_common/origins_common.libraries.yml
+++ b/origins_common/origins_common.libraries.yml
@@ -13,3 +13,9 @@ origins_common_claro_fixes:
   css:
     theme:
       css/claro.overrides.css: {}
+gtag_eucc_consent:
+  js:
+    js/gtag-eucc-consent.js: {}
+  dependencies:
+    - core/drupal
+    - core/drupalSettings

--- a/origins_common/origins_common.module
+++ b/origins_common/origins_common.module
@@ -115,6 +115,10 @@ function origins_common_preprocess_page(&$variables) {
   if ($theme->getName() === 'adminimal_theme') {
     $variables['#attached']['library'][] = 'origins_common/adminimal';
   }
+
+  // EUCC and Google Consent Mode. Add library to handle EUCC consent
+  // preferences and push event(s) to GTM.
+  $variables['#attached']['library'][] = 'origins_common/gtag_eucc_consent';
 }
 
 /**


### PR DESCRIPTION
Small snippet of JS that pushes a dataLayer event for GTM / Google Analytics that indicates when EUCC preferences have been loaded or changed.

This is required for Google Consent Mode tags in the GTM container which react to the event and update consent mode state based on cookie-agreed value set by EUCC module.