### PR TITLE
DEPT-896 ~ Override title property of Media Edit button

### DIFF
--- a/origins_ckeditor_enhancements/origins_ckeditor_enhancements.module
+++ b/origins_ckeditor_enhancements/origins_ckeditor_enhancements.module
@@ -5,8 +5,8 @@
  * Contains origins_ckeditor_enhancements.module.
  */
 
-use Drupal\ckeditor5\Plugin\CKEditor5PluginDefinition;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\ckeditor5\Plugin\CKEditor5PluginDefinition;
 
 /**
  * Implements hook_element_info_alter().

--- a/origins_common/origins_common.module
+++ b/origins_common/origins_common.module
@@ -5,12 +5,12 @@
  * Contains origins_common.module.
  */
 
-use Drupal\block\Entity\Block;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
+use Drupal\block\Entity\Block;
 use Drupal\facets\FacetInterface;
 use Drupal\node\Entity\Node;
 

--- a/origins_media/origins_media.module
+++ b/origins_media/origins_media.module
@@ -388,27 +388,3 @@ function origins_media_preprocess_media_oembed_iframe(&$variables) {
     $variables['media'] = str_replace('?feature=oembed', '?rel=0&feature=oembed', (string) $variables['media']);
   }
 }
-
-/**
- * Implements hook_field_widget_single_element_form_alter().
- */
-function origins_media_field_widget_single_element_form_alter(array &$element, FormStateInterface $form_state, array $context) {
-  $plugin_id = $context['widget']->getPluginId();
-
-  // Overrides the contrib module render array title which introduced a hidden span link in version 3.0.4.
-  if ($plugin_id == 'media_library_widget') {
-    if (version_compare(InstalledVersions::getPrettyVersion('drupal/media_library_edit'), '3.0.4') >= 0) {
-      $settings = $context['widget']->getThirdPartySettings('media_library_edit');
-      if (isset($settings['show_edit']) && $settings['show_edit']) {
-        if (isset($context['items'])) {
-          foreach ($context['items'] as $key => $item) {
-            $media = $item->entity;
-            if ($media && $media->access('update')) {
-              $element['selection'][$key]['media_edit']['#title'] = t('Edit media item');
-            }
-          }
-        }
-      }
-    }
-  }
-}

--- a/origins_media/origins_media.module
+++ b/origins_media/origins_media.module
@@ -5,6 +5,7 @@
  * Contains origins_media.module.
  */
 
+use Composer\InstalledVersions;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
@@ -385,5 +386,29 @@ function origins_media_preprocess_media_oembed_iframe(&$variables) {
   // media_test_oembed_preprocess_media_oembed_iframe().
   if ($variables['resource']->getProvider()->getName() === 'YouTube') {
     $variables['media'] = str_replace('?feature=oembed', '?rel=0&feature=oembed', (string) $variables['media']);
+  }
+}
+
+/**
+ * Implements hook_field_widget_single_element_form_alter().
+ */
+function origins_media_field_widget_single_element_form_alter(array &$element, FormStateInterface $form_state, array $context) {
+  $plugin_id = $context['widget']->getPluginId();
+
+  // Overrides the contrib module render array title which introduced a hidden span link in version 3.0.4.
+  if ($plugin_id == 'media_library_widget') {
+    if (version_compare(InstalledVersions::getPrettyVersion('drupal/media_library_edit'), '3.0.4') >= 0) {
+      $settings = $context['widget']->getThirdPartySettings('media_library_edit');
+      if (isset($settings['show_edit']) && $settings['show_edit']) {
+        if (isset($context['items'])) {
+          foreach ($context['items'] as $key => $item) {
+            $media = $item->entity;
+            if ($media && $media->access('update')) {
+              $element['selection'][$key]['media_edit']['#title'] = t('Edit media item');
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/origins_media/origins_media.module
+++ b/origins_media/origins_media.module
@@ -388,3 +388,27 @@ function origins_media_preprocess_media_oembed_iframe(&$variables) {
     $variables['media'] = str_replace('?feature=oembed', '?rel=0&feature=oembed', (string) $variables['media']);
   }
 }
+
+/**
+ * Implements hook_field_widget_single_element_form_alter().
+ */
+function origins_media_field_widget_single_element_form_alter(array &$element, FormStateInterface $form_state, array $context) {
+  $plugin_id = $context['widget']->getPluginId();
+
+  // Overrides the contrib module render array title which introduced a hidden span link in version 3.0.4.
+  if ($plugin_id == 'media_library_widget') {
+    if (version_compare(InstalledVersions::getPrettyVersion('drupal/media_library_edit'), '3.0.4') >= 0) {
+      $settings = $context['widget']->getThirdPartySettings('media_library_edit');
+      if (isset($settings['show_edit']) && $settings['show_edit']) {
+        if (isset($context['items'])) {
+          foreach ($context['items'] as $key => $item) {
+            $media = $item->entity;
+            if ($media && $media->access('update')) {
+              $element['selection'][$key]['media_edit']['#title'] = t('Edit media item');
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/origins_media/src/Form/OriginsEntityEmbedDialog.php
+++ b/origins_media/src/Form/OriginsEntityEmbedDialog.php
@@ -24,7 +24,7 @@ class OriginsEntityEmbedDialog extends EntityEmbedDialog {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, EditorInterface $editor = NULL, EmbedButtonInterface $embed_button = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state, EditorInterface|null $editor = NULL, EmbedButtonInterface|null $embed_button = NULL) {
     // Pass in our pre-set form_state into the origin entity embed form builder
     // so we can get the correct form output in the state we need it to be in
     // for location embeds (either new map or replace existing map).

--- a/origins_qa/src/Controller/QaAccountsManager.php
+++ b/origins_qa/src/Controller/QaAccountsManager.php
@@ -26,10 +26,10 @@ class QaAccountsManager extends ControllerBase {
   /**
    * {@inheritdoc}
    *
-   * @param \Drupal\Core\Form\FormBuilder $formBuilder
+   * @param \Drupal\Core\Form\FormBuilder|null $formBuilder
    *   The form builder.
    */
-  public function __construct(FormBuilder $formBuilder = NULL) {
+  public function __construct(FormBuilder|null $formBuilder = NULL) {
     // Note that $formBuilder will be NULL if calling from drush.
     $this->formBuilder = $formBuilder;
   }

--- a/origins_workflow/origins_workflow.module
+++ b/origins_workflow/origins_workflow.module
@@ -6,7 +6,6 @@
  */
 
 use Drupal\Component\Utility\NestedArray;
-use Drupal\content_moderation\Entity\ContentModerationStateInterface;
 use Drupal\Core\Entity\ContentEntityBase;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\RevisionLogInterface;

--- a/origins_workflow/src/Controller/ModerationStateController.php
+++ b/origins_workflow/src/Controller/ModerationStateController.php
@@ -3,11 +3,11 @@
 namespace Drupal\origins_workflow\Controller;
 
 use Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher;
-use Drupal\content_moderation\ModerationInformationInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\content_moderation\ModerationInformationInterface;
 use Drupal\node\NodeInterface;
 use Drupal\origins_workflow\Event\ModerationStateChangeEvent;
 use Drupal\workflows\StateInterface;

--- a/origins_workflow/src/Form/NewDraftOfPublishedForm.php
+++ b/origins_workflow/src/Form/NewDraftOfPublishedForm.php
@@ -53,10 +53,10 @@ class NewDraftOfPublishedForm extends ConfirmFormBase {
    *   The entity type manager.
    * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
    *   The date formatter service.
-   * @param \Drupal\Component\Datetime\TimeInterface $time
+   * @param \Drupal\Component\Datetime\TimeInterface|null $time
    *   The time service.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, DateFormatterInterface $date_formatter, TimeInterface $time = NULL) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, DateFormatterInterface $date_formatter, TimeInterface|null $time = NULL) {
     $this->entityTypeManager = $entity_type_manager;
     $this->dateFormatter = $date_formatter;
     $this->time = $time;

--- a/origins_workflow/src/Form/RevertToModerationStateForm.php
+++ b/origins_workflow/src/Form/RevertToModerationStateForm.php
@@ -3,13 +3,13 @@
 namespace Drupal\origins_workflow\Form;
 
 use Drupal\Component\Datetime\TimeInterface;
-use Drupal\content_moderation\ModerationInformationInterface;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Url;
+use Drupal\content_moderation\ModerationInformationInterface;
 use Drupal\node\NodeInterface;
 use Drupal\workflows\StateInterface;
 use Psr\Log\LoggerInterface;
@@ -109,10 +109,10 @@ class RevertToModerationStateForm extends ConfirmFormBase {
    *   The logger interface.
    * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
    *   The date formatter service.
-   * @param \Drupal\Component\Datetime\TimeInterface $time
+   * @param \Drupal\Component\Datetime\TimeInterface|null $time
    *   The time service.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, ModerationInformationInterface $moderation_information, MessengerInterface $messenger, RequestStack $request, LoggerInterface $logger, DateFormatterInterface $date_formatter, TimeInterface $time = NULL) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, ModerationInformationInterface $moderation_information, MessengerInterface $messenger, RequestStack $request, LoggerInterface $logger, DateFormatterInterface $date_formatter, TimeInterface|null $time = NULL) {
     $this->entityTypeManager = $entity_type_manager;
     $this->moderationInformation = $moderation_information;
     $this->messenger = $messenger;

--- a/origins_workflow/tests/src/Functional/AuditTest.php
+++ b/origins_workflow/tests/src/Functional/AuditTest.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\Tests\origins_workflow\Functional;
 
+use Drupal\Tests\BrowserTestBase;
 use Drupal\node\Entity\Node;
 use Drupal\origins_workflow\Controller\AuditController;
-use Drupal\Tests\BrowserTestBase;
 
 /**
  * Tests audit workflow.


### PR DESCRIPTION
Latest Media Library Edit version changed the title from plain text to a hidden span which breaks our theming so this hook changes the title back to plain text.