### PR TITLE
CORP-381

### DIFF
--- a/origins_internal_link_checker/origins_internal_link_checker.info.yml
+++ b/origins_internal_link_checker/origins_internal_link_checker.info.yml
@@ -1,0 +1,5 @@
+name: 'Origins Internal Link Checker'
+type: module
+description: 'Origins internal link checking and correction'
+core_version_requirement: ^8.8 || ^9 || ^10 || ^11
+package: 'Unity'

--- a/origins_internal_link_checker/origins_internal_link_checker.info.yml
+++ b/origins_internal_link_checker/origins_internal_link_checker.info.yml
@@ -2,4 +2,4 @@ name: 'Origins Internal Link Checker'
 type: module
 description: 'Origins internal link checking and correction'
 core_version_requirement: ^8.8 || ^9 || ^10 || ^11
-package: 'Unity'
+package: 'NICS: Origins'

--- a/origins_internal_link_checker/origins_internal_link_checker.links.menu.yml
+++ b/origins_internal_link_checker/origins_internal_link_checker.links.menu.yml
@@ -1,0 +1,6 @@
+link_checker.link_checker_form:
+  title: 'Origins Internal Link Checker'
+  route_name: origins_internal_link_checker.link_checker_form
+  description: 'Configure internal link checking and correction'
+  parent: origins.admin_config
+  weight: 99

--- a/origins_internal_link_checker/origins_internal_link_checker.module
+++ b/origins_internal_link_checker/origins_internal_link_checker.module
@@ -88,24 +88,30 @@ function origins_internal_link_checker__convert_absolute_link(&$body_text, $orig
  * Utility function to add all domains and extensions for the current site.
  */
 function origins_internal_link_checker__urls_to_replace(): string {
-  // Get the host name of the site and remove the domain extension.
+  // Get the host name of this site.
   $host = \Drupal::request()->getHost();
   // List all domain protocols and extensions for our platform and local environments.
   $protocols = ['http://', 'http://www.', 'https://', 'https://www.'];
+  // Retrieve any extra domain names that have been added on the config form.
   $config = \Drupal::config('origins_internal_link_checker.linksettings');
-  $domains = $config->get('site_url_list') ?? [];
-  $domains = explode(PHP_EOL, $domains);
+  $domains = $config->get('site_url_list');
+  if (empty($domains)) {
+    $domains = [];
+  } else {
+    $domains = explode(PHP_EOL, $domains);
+  }
   $domains[] = $host;
   foreach ($domains as $key => $domain) {
     // Strip 'www' from hostname.
     $domain = str_replace('www.', '', $domain);
+    // Strip protocols from hostname.
     foreach ($protocols as $protocol) {
       $domain = str_replace($protocol, '', $domain);
     }
     $domains[$key] = $domain;
   }
   $urls_to_replace = '';
-  // Loop through and add all protocols and extensions to the current site.
+  // Loop through and add all protocols and extensions to all domains.
   foreach ($protocols as $protocol) {
     foreach ($domains as $domain) {
       $urls_to_replace .= $protocol . $domain . "\r\n";

--- a/origins_internal_link_checker/origins_internal_link_checker.module
+++ b/origins_internal_link_checker/origins_internal_link_checker.module
@@ -18,40 +18,54 @@ function origins_internal_link_checker_entity_presave(EntityInterface $entity) {
     return;
   }
   if ($entity instanceof ContentEntityInterface) {
-    if ($entity->hasField('body')) {
-      $body = $entity->get('body')->value ?? '';
-      $format = $entity->get('body')->format ?? '';
-      // Get list of urls to exclude (these have been added at /admin/config/origins_internal_link_checker/link_checker_form).
-      $config = \Drupal::config('origins_internal_link_checker.linksettings');
-      // Make sure the array items are clean.
-      $exclude_list_bare = $config->get('site_url_list_exclude');
-      if (!empty($exclude_list_bare)) {
-        $exclude_url_list = preg_split('/\r\n|\r|\n/', $config->get('site_url_list_exclude'));
+    $text_fields = [];
+    $fields = $entity->getFieldDefinitions();
+    foreach ($fields as $field_name => $field) {
+      $type = $field->getType();
+      if (preg_match('/text/', $type)) {
+        $text_fields[] = $field_name;
       }
-      else {
-        $exclude_url_list = [];
+    }
+    if (count($text_fields) > 0) {
+      foreach ($text_fields as $field) {
+        origins_internal_link_checker_process_field($entity, $field);
       }
-      $matches = [];
-      // Look for all anchors in the body field.
-      if (preg_match_all('|href\=[\'"]+([^ >"\']*)[\'"]+[^>]*>|', $body, $matches)) {
-        if (count($matches) > 1) {
-          foreach ($matches[1] as $original_link) {
-            // If we have any URL's to exclude then don't convert to a relative URL.
-            if (!in_array($original_link, $exclude_url_list)) {
-              // So we have an anchor, does it look like a relative link
-              // or an absolute?
-              $matches2 = [];
-              if (preg_match('|http://(.*)|', $original_link, $matches2) ||
-                preg_match('|https://(.*)|', $original_link, $matches2)) {
-                // This is an absolute URL does it match one of the domain names specified
-                // at /admin/config/origins_internal_link_checker/link_checker_form ?
-                $body = origins_internal_link_checker__convert_absolute_link($body, $original_link);
-              }
-            }
+    }
+  }
+}
+
+function origins_internal_link_checker_process_field($entity, $field) {
+  $body = $entity->get($field)->value ?? '';
+  $format = $entity->get($field)->format ?? '';
+  // Get list of urls to exclude (these have been added at /admin/config/origins_internal_link_checker/link_checker_form).
+  $config = \Drupal::config('origins_internal_link_checker.linksettings');
+  // Make sure the array items are clean.
+  $exclude_list_bare = $config->get('site_url_list_exclude');
+  if (!empty($exclude_list_bare)) {
+    $exclude_url_list = preg_split('/\r\n|\r|\n/', $config->get('site_url_list_exclude'));
+  }
+  else {
+    $exclude_url_list = [];
+  }
+  $matches = [];
+  // Look for all anchors in the body field.
+  if (preg_match_all('|href\=[\'"]+([^ >"\']*)[\'"]+[^>]*>|', $body, $matches)) {
+    if (count($matches) > 1) {
+      foreach ($matches[1] as $original_link) {
+        // If we have any URL's to exclude then don't convert to a relative URL.
+        if (!in_array($original_link, $exclude_url_list)) {
+          // So we have an anchor, does it look like a relative link
+          // or an absolute?
+          $matches2 = [];
+          if (preg_match('|http://(.*)|', $original_link, $matches2) ||
+            preg_match('|https://(.*)|', $original_link, $matches2)) {
+            // This is an absolute URL does it match one of the domain names specified
+            // at /admin/config/origins_internal_link_checker/link_checker_form ?
+            $body = origins_internal_link_checker__convert_absolute_link($body, $original_link);
           }
-          $entity->set('body', ['value' => $body, 'format' => $format]);
         }
       }
+      $entity->set($field, ['value' => $body, 'format' => $format]);
     }
   }
 }

--- a/origins_internal_link_checker/origins_internal_link_checker.module
+++ b/origins_internal_link_checker/origins_internal_link_checker.module
@@ -90,16 +90,20 @@ function origins_internal_link_checker__convert_absolute_link(&$body_text, $orig
 function origins_internal_link_checker__urls_to_replace(): string {
   // Get the host name of the site and remove the domain extension.
   $host = \Drupal::request()->getHost();
-  // Strip 'www' from hostname.
-  $host = str_replace('www.', '', $host);
   // List all domain protocols and extensions for our platform and local environments.
   $protocols = ['http://', 'http://www.', 'https://', 'https://www.'];
   $config = \Drupal::config('origins_internal_link_checker.linksettings');
   $domains = $config->get('site_url_list') ?? [];
-  foreach ($domains as $key => $domain) {
-    $domains[$key] = str_replace('www', '', $domain);
-  }
+  $domains = explode(PHP_EOL, $domains);
   $domains[] = $host;
+  foreach ($domains as $key => $domain) {
+    // Strip 'www' from hostname.
+    $domain = str_replace('www.', '', $domain);
+    foreach ($protocols as $protocol) {
+      $domain = str_replace($protocol, '', $domain);
+    }
+    $domains[$key] = $domain;
+  }
   $urls_to_replace = '';
   // Loop through and add all protocols and extensions to the current site.
   foreach ($protocols as $protocol) {

--- a/origins_internal_link_checker/origins_internal_link_checker.module
+++ b/origins_internal_link_checker/origins_internal_link_checker.module
@@ -116,7 +116,8 @@ function origins_internal_link_checker__urls_to_replace(): string {
   $domains = $config->get('site_url_list');
   if (empty($domains)) {
     $domains = [];
-  } else {
+  }
+  else {
     $domains = explode(PHP_EOL, $domains);
   }
   $domains[] = $host;

--- a/origins_internal_link_checker/origins_internal_link_checker.module
+++ b/origins_internal_link_checker/origins_internal_link_checker.module
@@ -63,18 +63,7 @@ function origins_internal_link_checker__convert_absolute_link(&$body_text, $orig
   // Get list of urls to replace
   // (these have been added at
   // /admin/config/origins_internal_link_checker/link_checker_form )
-  $config = \Drupal::config('origins_internal_link_checker.linksettings');
   $replace_url_list = origins_internal_link_checker__urls_to_replace();
-  $site_url_list = $config->get('site_url_list');
-  // Allow for null config.
-  if (!empty($site_url_list)) {
-    $replace_url_list .= $site_url_list;
-  }
-  if (strlen($replace_url_list) == 0) {
-    \Drupal::messenger()
-      ->addMessage(t("Please set some URLs at /admin/config/origins_internal_link_checker/link_checker_form"), "error");
-    return $body_text;
-  }
   $replace_url_list = explode(PHP_EOL, $replace_url_list);
   // Remove empty array items.
   $replace_url_list = array_filter($replace_url_list);
@@ -101,34 +90,21 @@ function origins_internal_link_checker__convert_absolute_link(&$body_text, $orig
 function origins_internal_link_checker__urls_to_replace(): string {
   // Get the host name of the site and remove the domain extension.
   $host = \Drupal::request()->getHost();
-  if (preg_match('/\S*?\.(gov.uk|org.uk|co.uk|com(\/|$)|net|eu|org|uk)/', $host, $matches)) {
-    $host = $matches[0];
-  }
   // Strip 'www' from hostname.
   $host = str_replace('www.', '', $host);
   // List all domain protocols and extensions for our platform and local environments.
   $protocols = ['http://', 'http://www.', 'https://', 'https://www.'];
-  $extensions = [
-    '.lndo.site/',
-    '/',
-    // Unity 1 platform environments.
-    '.edge-uhfrady-6tlkpwbr6tndk.uk-1.platformsh.site/',
-    '.uat-nvcvooy-6tlkpwbr6tndk.uk-1.platformsh.site/',
-    '.main-bvxea6i-6tlkpwbr6tndk.uk-1.platformsh.site/',
-    // Unity 2 platform environments.
-    '.edge-uhfrady-kamkoebtv74zm.uk-1.platformsh.site/',
-    '.uat-nvcvooy-kamkoebtv74zm.uk-1.platformsh.site/',
-    '.main-bvxea6i-kamkoebtv74zm.uk-1.platformsh.site/',
-    // Unity 3 platform environments.
-    '.edge-uhfrady-vnetibjd44moa.uk-1.platformsh.site/',
-    '.uat-nvcvooy-vnetibjd44moa.uk-1.platformsh.site/',
-    '.main-bvxea6i-vnetibjd44moa.uk-1.platformsh.site/',
-  ];
+  $config = \Drupal::config('origins_internal_link_checker.linksettings');
+  $domains = $config->get('site_url_list') ?? [];
+  foreach ($domains as $key => $domain) {
+    $domains[$key] = str_replace('www', '', $domain);
+  }
+  $domains[] = $host;
   $urls_to_replace = '';
   // Loop through and add all protocols and extensions to the current site.
   foreach ($protocols as $protocol) {
-    foreach ($extensions as $extension) {
-      $urls_to_replace .= $protocol . $host . $extension . "\r\n";
+    foreach ($domains as $domain) {
+      $urls_to_replace .= $protocol . $domain . "\r\n";
     }
   }
   return $urls_to_replace;

--- a/origins_internal_link_checker/origins_internal_link_checker.module
+++ b/origins_internal_link_checker/origins_internal_link_checker.module
@@ -20,6 +20,7 @@ function origins_internal_link_checker_entity_presave(EntityInterface $entity) {
   if ($entity instanceof ContentEntityInterface) {
     $text_fields = [];
     $fields = $entity->getFieldDefinitions();
+    // See if there are any text fields in this entity.
     foreach ($fields as $field_name => $field) {
       $type = $field->getType();
       if (preg_match('/text/', $type)) {
@@ -28,14 +29,18 @@ function origins_internal_link_checker_entity_presave(EntityInterface $entity) {
     }
     if (count($text_fields) > 0) {
       foreach ($text_fields as $field) {
+        // Check each text field for internal urls.
         origins_internal_link_checker_process_field($entity, $field);
       }
     }
   }
 }
 
+/**
+ * Utility function to process links in each text field.
+ */
 function origins_internal_link_checker_process_field($entity, $field) {
-  $body = $entity->get($field)->value ?? '';
+  $text = $entity->get($field)->value ?? '';
   $format = $entity->get($field)->format ?? '';
   // Get list of urls to exclude (these have been added at /admin/config/origins_internal_link_checker/link_checker_form).
   $config = \Drupal::config('origins_internal_link_checker.linksettings');
@@ -49,7 +54,7 @@ function origins_internal_link_checker_process_field($entity, $field) {
   }
   $matches = [];
   // Look for all anchors in the body field.
-  if (preg_match_all('|href\=[\'"]+([^ >"\']*)[\'"]+[^>]*>|', $body, $matches)) {
+  if (preg_match_all('|href\=[\'"]+([^ >"\']*)[\'"]+[^>]*>|', $text, $matches)) {
     if (count($matches) > 1) {
       foreach ($matches[1] as $original_link) {
         // If we have any URL's to exclude then don't convert to a relative URL.
@@ -61,11 +66,11 @@ function origins_internal_link_checker_process_field($entity, $field) {
             preg_match('|https://(.*)|', $original_link, $matches2)) {
             // This is an absolute URL does it match one of the domain names specified
             // at /admin/config/origins_internal_link_checker/link_checker_form ?
-            $body = origins_internal_link_checker__convert_absolute_link($body, $original_link);
+            $text = origins_internal_link_checker__convert_absolute_link($text, $original_link);
           }
         }
       }
-      $entity->set($field, ['value' => $body, 'format' => $format]);
+      $entity->set($field, ['value' => $text, 'format' => $format]);
     }
   }
 }
@@ -125,7 +130,7 @@ function origins_internal_link_checker__urls_to_replace(): string {
     $domains[$key] = $domain;
   }
   $urls_to_replace = '';
-  // Loop through and add all protocols and extensions to all domains.
+  // Loop through and add all domains.
   foreach ($protocols as $protocol) {
     foreach ($domains as $domain) {
       $urls_to_replace .= $protocol . $domain . "\r\n";

--- a/origins_internal_link_checker/origins_internal_link_checker.module
+++ b/origins_internal_link_checker/origins_internal_link_checker.module
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * @file
+ * Contains origins_internal_link_checker.module.
+ */
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Implements hook_entity_presave().
+ */
+function origins_internal_link_checker_entity_presave(EntityInterface $entity) {
+  // If this hook has been invoked from a migration, bail out.
+  $page = \Drupal::request()->getRequestUri();
+  if (preg_match('|^\/batch|', $page) || ($page == '/')) {
+    return;
+  }
+  if ($entity instanceof ContentEntityInterface) {
+    if ($entity->hasField('body')) {
+      $body = $entity->get('body')->value ?? '';
+      $format = $entity->get('body')->format ?? '';
+      // Get list of urls to exclude (these have been added at /admin/config/origins_internal_link_checker/link_checker_form).
+      $config = \Drupal::config('origins_internal_link_checker.linksettings');
+      // Make sure the array items are clean.
+      $exclude_list_bare = $config->get('site_url_list_exclude');
+      if (!empty($exclude_list_bare)) {
+        $exclude_url_list = preg_split('/\r\n|\r|\n/', $config->get('site_url_list_exclude'));
+      }
+      else {
+        $exclude_url_list = [];
+      }
+      $matches = [];
+      // Look for all anchors in the body field.
+      if (preg_match_all('|href\=[\'"]+([^ >"\']*)[\'"]+[^>]*>|', $body, $matches)) {
+        if (count($matches) > 1) {
+          foreach ($matches[1] as $original_link) {
+            // If we have any URL's to exclude then don't convert to a relative URL.
+            if (!in_array($original_link, $exclude_url_list)) {
+              // So we have an anchor, does it look like a relative link
+              // or an absolute?
+              $matches2 = [];
+              if (preg_match('|http://(.*)|', $original_link, $matches2) ||
+                preg_match('|https://(.*)|', $original_link, $matches2)) {
+                // This is an absolute URL does it match one of the domain names specified
+                // at /admin/config/origins_internal_link_checker/link_checker_form ?
+                $body = origins_internal_link_checker__convert_absolute_link($body, $original_link);
+              }
+            }
+          }
+          $entity->set('body', ['value' => $body, 'format' => $format]);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Utility function to convert internal link to relative.
+ */
+function origins_internal_link_checker__convert_absolute_link(&$body_text, $original_link) {
+  // Get list of urls to replace
+  // (these have been added at
+  // /admin/config/origins_internal_link_checker/link_checker_form )
+  $config = \Drupal::config('origins_internal_link_checker.linksettings');
+  $replace_url_list = origins_internal_link_checker__urls_to_replace();
+  $site_url_list = $config->get('site_url_list');
+  // Allow for null config.
+  if (!empty($site_url_list)) {
+    $replace_url_list .= $site_url_list;
+  }
+  if (strlen($replace_url_list) == 0) {
+    \Drupal::messenger()
+      ->addMessage(t("Please set some URLs at /admin/config/origins_internal_link_checker/link_checker_form"), "error");
+    return $body_text;
+  }
+  $replace_url_list = explode(PHP_EOL, $replace_url_list);
+  // Remove empty array items.
+  $replace_url_list = array_filter($replace_url_list);
+  foreach ($replace_url_list as $replace_url) {
+    // Make sure url is 'clean'.
+    $replace_url = str_replace(["\n", "\t", "\r"], '', $replace_url);
+    // Make sure that there is a trailing slash.
+    if (!preg_match('|\/$|', $replace_url)) {
+      $replace_url .= '/';
+    }
+    // Does the start of this link match one of the
+    // urls that we are looking for ?
+    if (str_contains($original_link, $replace_url)) {
+      // We have a match, change this absolute link to a relative link. Only target href values.
+      $body_text = preg_replace('~href\=[\'"]+' . $replace_url . '~', 'href="/', $body_text, 1);
+    }
+  }
+  return $body_text;
+}
+
+/**
+ * Utility function to add all domains and extensions for the current site.
+ */
+function origins_internal_link_checker__urls_to_replace(): string {
+  // Get the host name of the site and remove the domain extension.
+  $host = \Drupal::request()->getHost();
+  if (preg_match('/\S*?\.(gov.uk|org.uk|co.uk|com(\/|$)|net|eu|org|uk)/', $host, $matches)) {
+    $host = $matches[0];
+  }
+  // Strip 'www' from hostname.
+  $host = str_replace('www.', '', $host);
+  // List all domain protocols and extensions for our platform and local environments.
+  $protocols = ['http://', 'http://www.', 'https://', 'https://www.'];
+  $extensions = [
+    '.lndo.site/',
+    '/',
+    // Unity 1 platform environments.
+    '.edge-uhfrady-6tlkpwbr6tndk.uk-1.platformsh.site/',
+    '.uat-nvcvooy-6tlkpwbr6tndk.uk-1.platformsh.site/',
+    '.main-bvxea6i-6tlkpwbr6tndk.uk-1.platformsh.site/',
+    // Unity 2 platform environments.
+    '.edge-uhfrady-kamkoebtv74zm.uk-1.platformsh.site/',
+    '.uat-nvcvooy-kamkoebtv74zm.uk-1.platformsh.site/',
+    '.main-bvxea6i-kamkoebtv74zm.uk-1.platformsh.site/',
+    // Unity 3 platform environments.
+    '.edge-uhfrady-vnetibjd44moa.uk-1.platformsh.site/',
+    '.uat-nvcvooy-vnetibjd44moa.uk-1.platformsh.site/',
+    '.main-bvxea6i-vnetibjd44moa.uk-1.platformsh.site/',
+  ];
+  $urls_to_replace = '';
+  // Loop through and add all protocols and extensions to the current site.
+  foreach ($protocols as $protocol) {
+    foreach ($extensions as $extension) {
+      $urls_to_replace .= $protocol . $host . $extension . "\r\n";
+    }
+  }
+  return $urls_to_replace;
+}

--- a/origins_internal_link_checker/origins_internal_link_checker.routing.yml
+++ b/origins_internal_link_checker/origins_internal_link_checker.routing.yml
@@ -1,0 +1,9 @@
+unity_internal_link_checker.link_checker_form:
+  path: '/admin/config/origins_internal_link_checker/link_checker_form'
+  defaults:
+    _form: '\Drupal\unity_internal_link_checker\Form\LinkCheckerForm'
+    _title: 'Unity Link Checker'
+  requirements:
+    _role: 'administrator'
+  options:
+    _admin_route: TRUE

--- a/origins_internal_link_checker/origins_internal_link_checker.routing.yml
+++ b/origins_internal_link_checker/origins_internal_link_checker.routing.yml
@@ -1,8 +1,8 @@
-unity_internal_link_checker.link_checker_form:
+origins_internal_link_checker.link_checker_form:
   path: '/admin/config/origins_internal_link_checker/link_checker_form'
   defaults:
-    _form: '\Drupal\unity_internal_link_checker\Form\LinkCheckerForm'
-    _title: 'Unity Link Checker'
+    _form: '\Drupal\origins_internal_link_checker\Form\LinkCheckerForm'
+    _title: 'Origins Link Checker'
   requirements:
     _role: 'administrator'
   options:

--- a/origins_internal_link_checker/src/Form/LinkCheckerForm.php
+++ b/origins_internal_link_checker/src/Form/LinkCheckerForm.php
@@ -32,8 +32,8 @@ class LinkCheckerForm extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config('origins_internal_link_checker.linksettings');
 
-    $message = "All environment domains (Local, Edge, UAT, Main) are already being stripped of absolute links and changed to relative for this site.";
-    $message .= "<br/>List any extra domain names here that must be stripped out of absolute links and changed to relative as they are saved.";
+    $message = "The current domain for this site is already being stripped out of absolute links and changed to relative.";
+    $message .= "<br/>List any extra domain names here (possibly UAT or edge domains) that must be stripped out of absolute links and changed to relative as they are saved.";
     $message .= "<br/>For example adding 'http://uregni.gov.uk' here will cause any links starting with that domain name to be saved as relative links instead.";
     $message .= "<br/>You may add as many domain names as you like, along with the appropriate 'http' or 'https' protocol.";
 

--- a/origins_internal_link_checker/src/Form/LinkCheckerForm.php
+++ b/origins_internal_link_checker/src/Form/LinkCheckerForm.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Drupal\origins_internal_link_checker\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements admin form to allow setting of audit text.
+ */
+class LinkCheckerForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'origins_internal_link_checker.linksettings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'link_checker_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('origins_internal_link_checker.linksettings');
+
+    $message = "All environment domains (Local, Edge, UAT, Main) are already being stripped of absolute links and changed to relative for this site.";
+    $message .= "<br/>List any extra domain names here that must be stripped out of absolute links and changed to relative as they are saved.";
+    $message .= "<br/>For example adding 'http://uregni.gov.uk' here will cause any links starting with that domain name to be saved as relative links instead.";
+    $message .= "<br/>You may add as many domain names as you like, along with the appropriate 'http' or 'https' protocol.";
+
+    $message_exclude = "If there are any specific URL's that are not to be made a relative URL then add the full URL in this field.";
+    $message_exclude .= "<br/>For example adding https://employmenttribunalsni.co.uk/OITFET_IWS/Login.aspx will keep this link as it is.";
+    $message_exclude .= "<br/>You may add as many domain names as you like, along with the appropriate 'http' or 'https' protocol.";
+
+    $form['site_url_list'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Site URLs'),
+      '#description' => $this->t($message),
+      '#default_value' => $config->get('site_url_list'),
+    ];
+
+    $form['site_url_list_exclude'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Site URLs to exclude'),
+      '#description' => $this->t($message_exclude),
+      '#default_value' => $config->get('site_url_list_exclude'),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    $form_keys = ['site_url_list', 'site_url_list_exclude'];
+
+    foreach ($form_keys as $form_key) {
+      if ($form_state->getValue($form_key)) {
+        $replace_url_list = explode(PHP_EOL, $form_state->getValue($form_key));
+        foreach ($replace_url_list as $replace_url) {
+          // Make sure url is 'clean'.
+          $replace_url = str_replace(["\n", "\t", "\r"], '', $replace_url);
+          $pass = FALSE;
+          if (preg_match('|^http:\/\/|', $replace_url) || preg_match('|^https:\/\/|', $replace_url)) {
+            $pass = TRUE;
+          }
+          if (!$pass) {
+            $form_state->setErrorByName($form_key, $this->t("URLs must start with 'http' or 'https'"));
+          }
+        }
+      }
+    }
+    parent::validateForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+
+    $this->config('origins_internal_link_checker.linksettings')
+      ->set('site_url_list', $form_state->getValue('site_url_list'))
+      ->set('site_url_list_exclude', $form_state->getValue('site_url_list_exclude'))
+      ->save();
+  }
+
+}


### PR DESCRIPTION
Ports the Unity Internal Link Checker over to Origins (with a few improvements) so that it can be used in Corp Lite and anywhere else that it might be needed.