### PR TITLE
Adjust which hook is used to replace core's media thumbnails

### DIFF
--- a/origins_media/css/entity-browser-entity-reference.css
+++ b/origins_media/css/entity-browser-entity-reference.css
@@ -1,3 +1,11 @@
 .entities-list .item-container > input.button {
   display: inline-block;
 }
+
+/* Stabilize media library preview layout across wrapper variants. */
+.field--widget-media-library-widget .media-library-item__preview,
+.media-library-widget .media-library-item__preview {
+  display: inline-block;
+  padding: 0;
+  vertical-align: top;
+}

--- a/origins_media/css/file-link.css
+++ b/origins_media/css/file-link.css
@@ -118,6 +118,10 @@
     background-color: #000;
 }
 
+.js-media-library-widget .media-library-item--grid .field--name-thumbnail {
+    background-color: #fff;
+}
+
 .media-library-views-form .media-library-item--grid .field--name-thumbnail img {
     height: 110px;
     -o-object-fit: contain;
@@ -228,4 +232,21 @@
     background-size: 40px auto;
     border-radius: 20px;
     opacity: .75;
+}
+
+/* Ensure icon thumbnails behave like real thumbnails in Media Library. */
+.media-library-item__preview .file--media-library-preview.file--ico {
+  display: block;
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-height: 50px; /* matches grid image height */
+  text-align: center;
+}
+.media-library-item__preview .file--ico::before {
+  content: '';
+  display: inline-block;
+  width: 40px;
+  height: 50px;
+  margin: 5px 0;
 }

--- a/origins_media/origins_media.module
+++ b/origins_media/origins_media.module
@@ -5,7 +5,6 @@
  * Contains origins_media.module.
  */
 
-use Composer\InstalledVersions;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
@@ -259,66 +258,16 @@ function origins_media_views_pre_render(ViewExecutable $view) {
  * Implements hook_preprocess_media().
  */
 function origins_media_preprocess_media(array &$variables) {
-
-  if ($variables['view_mode'] !== 'media_library') {
+  if (($variables['view_mode'] ?? '') !== 'media_library') {
     return;
   }
 
+  /** @var \Drupal\media\MediaInterface $media_entity */
   $media_entity = $variables['media'];
+  $variables['attributes']['class'][] = 'media-' . $media_entity->bundle();
 
-  // Add class to the media entity wrapper to identify the media type.
-  $variables["attributes"]['class'][] = 'media-' . $media_entity->bundle();
-
-  // Replace generic document icons with a mimetype specific icon.
-  if ($media_entity->bundle() === 'document' || $media_entity->bundle() === 'secure_file') {
-    $file_storage = \Drupal::entityTypeManager()->getStorage('file');
-
-    $media_fields = [
-      'field_media_file',
-      'field_media_file_1',
-      'field_media_file_2',
-    ];
-
-    foreach ($media_fields as $media_field) {
-      if ($media_entity->hasField($media_field)) {
-        // Get the underlying file associated with this document entity.
-        $file = $file_storage->load($media_entity->$media_field->target_id);
-
-        if ($file instanceof FileInterface === FALSE) {
-          return;
-        }
-
-        $mimetype = $file->getMimeType();
-
-        // There shouldn't be an image file here, but just in case, screen for it
-        // as if it's genuine it likely has its own thumbnail so we would want to
-        // keep that.
-        if (preg_match('/jpeg|jpg|gif|png/', $mimetype)) {
-          return;
-        }
-
-        $simple_mimetypes = \Drupal::service('origins_media.pretty_mime_types')
-          ->getSimpleMimeTypes();
-        $pretty_mimetypes = \Drupal::service('origins_media.pretty_mime_types')
-          ->getMimeTypes();
-
-        // Replace the original image_style render element with a bespoke HTML
-        // element.
-        $variables['content']['thumbnail'] = [
-          '#type' => 'html_tag',
-          '#tag' => 'div',
-          '#attributes' => [
-            'class' => [
-              'file--media-library-preview',
-              'file--ico',
-              'file--ico__' . $simple_mimetypes[$mimetype],
-            ],
-            'aria-label' => $pretty_mimetypes[$mimetype],
-          ],
-        ];
-      }
-    }
-  }
+  // Ensure our media-library CSS is present on entity forms too (not just Views).
+  $variables['#attached']['library'][] = 'origins_media/media_library_styles';
 }
 
 /**
@@ -397,5 +346,75 @@ function origins_media_preprocess_media_oembed_iframe(&$variables) {
   // media_test_oembed_preprocess_media_oembed_iframe().
   if ($variables['resource']->getProvider()->getName() === 'YouTube') {
     $variables['media'] = str_replace('?feature=oembed', '?rel=0&feature=oembed', (string) $variables['media']);
+  }
+}
+
+/**
+ * Implements hook_preprocess_field().
+ */
+function origins_media_preprocess_field(&$variables) {
+  $element = $variables['element'];
+
+  // Bail out early if we're not looking at the correct view mode.
+  if (($element['#view_mode'] ?? '') !== 'media_library') {
+    return;
+  }
+  if (($element['#field_name'] ?? '') !== 'thumbnail') {
+    return;
+  }
+
+  $media_entity = $element['#object'] ?? NULL;
+  if (!$media_entity instanceof MediaInterface) {
+    return;
+  }
+
+  if (!in_array($media_entity->bundle(), ['document', 'secure_file'], TRUE)) {
+    return;
+  }
+
+  // Find the real file behind the document media.
+  $file = NULL;
+  foreach (['field_media_file', 'field_media_file_1', 'field_media_file_2'] as $field_name) {
+    if ($media_entity->hasField($field_name) && !$media_entity->get($field_name)->isEmpty()) {
+      $file = $media_entity->get($field_name)->entity;
+      break;
+    }
+  }
+
+  if (!$file instanceof FileInterface) {
+    return;
+  }
+
+  $mimetype = $file->getMimeType();
+
+  if (preg_match('/^image\//', $mimetype)) {
+    return;
+  }
+
+  $pretty = \Drupal::service('origins_media.pretty_mime_types')->getMimeTypes();
+  $simple = \Drupal::service('origins_media.pretty_mime_types')->getSimpleMimeTypes();
+
+  $filetype = $simple[$mimetype] ?? 'file';
+  $label = $pretty[$mimetype] ?? $mimetype;
+
+  // Replace only the first item render element.
+  if (!empty($variables['items'][0]['content'])) {
+    $variables['items'][0]['content'] = [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => [
+          'file--media-library-preview',
+          'file--ico',
+          'file--ico__' . $filetype,
+        ],
+        'aria-label' => $label,
+        'role' => 'img',
+      ],
+      '#attached' => [
+        'library' => [
+          'origins_media/media_library_styles',
+        ],
+      ],
+    ];
   }
 }


### PR DESCRIPTION
Preprocess media loses some of the deeper render metadata and results in occasionally zero height/missing media preview images.

Preprocess field replaces part of the image which core media renders in the widget and works with both nidirect and dept image formatters whether fixed or responsive image.